### PR TITLE
PR for https://github.com/paypal/squbs/issues/20

### DIFF
--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/UnicomplexSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/UnicomplexSpec.scala
@@ -178,6 +178,11 @@ class UnicomplexSpec extends TestKit(UnicomplexSpec.boot.actorSystem) with Impli
       }
 
       IO(Http) ! HttpRequest(HttpMethods.POST, Uri(s"http://127.0.0.1:$port/withstash/"), entity = HttpEntity("request message"))
+      within(timeout.duration) {
+        val resp0 = expectMsgType[HttpResponse]
+        resp0.status shouldBe StatusCodes.Accepted
+      }
+
       IO(Http) ! HttpRequest(HttpMethods.GET, Uri(s"http://127.0.0.1:$port/withstash/"))
 			within(timeout.duration) {
         val resp1 = expectMsgType[HttpResponse]
@@ -186,11 +191,16 @@ class UnicomplexSpec extends TestKit(UnicomplexSpec.boot.actorSystem) with Impli
       }
 
       IO(Http) ! HttpRequest(HttpMethods.PUT, Uri(s"http://127.0.0.1:$port/withstash/"))
+      within(timeout.duration) {
+        val resp0 = expectMsgType[HttpResponse]
+        resp0.status shouldBe StatusCodes.Created
+      }
+
       IO(Http) ! HttpRequest(HttpMethods.GET, Uri(s"http://127.0.0.1:$port/withstash/"))
 			within(timeout.duration) {
 				val resp2 = expectMsgType[HttpResponse]
 				resp2.status shouldBe StatusCodes.OK
-				resp2.entity.asString shouldBe Seq("request message").toString
+				resp2.entity.asString shouldBe Seq("request message").toString // This line fails inconsistently.
 			}
     }
 

--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/stashcube/StashCubeSvc.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/stashcube/StashCubeSvc.scala
@@ -18,7 +18,8 @@ package org.squbs.unicomplex.stashcube
 
 import akka.actor.{Actor, Stash}
 import spray.http.HttpMethods._
-import spray.http.{HttpRequest, HttpResponse}
+import spray.http.StatusCodes._
+import spray.http.{HttpEntity, HttpRequest, HttpResponse}
 
 import scala.collection.mutable.ListBuffer
 
@@ -29,9 +30,13 @@ class StashCubeSvc extends Actor with Stash {
 	override def receive = {
 		case req: HttpRequest if req.method == POST =>
 			stash()
+			val resp = HttpResponse(status = Accepted, entity = HttpEntity("Stashed away!"))
+      sender() ! resp
 		case req: HttpRequest if req.method == PUT =>
 			context.become(report)
-			unstashAll()
+      val resp = HttpResponse(status = Created, entity = HttpEntity("Un-stashed"))
+      sender() ! resp
+      unstashAll()
 		case req: HttpRequest if req.method == GET =>
 			val resp = HttpResponse(entity = msgList.toSeq.toString())
 			sender() ! resp


### PR DESCRIPTION
Always send a response from StashCubeSvc, never hold on to requests. An HTTP request is never truly asynchronous and does need a valid response for every request. Also this unwinds the timing issue to ensure every previous step has been finished before testing the next step.