### PR TITLE
Validation Directives for squbs #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ squbs (pronounced "skewbs")is a software container and a suite of components ena
   1. Orchestration DSL allowing developers to describe their orchestration sequence in an extremely concise manner while running the whole orchestration asynchronously, thus largely simplifying code and reduces latency for the application.
   2. Asynchronous systems depend heavily on timeouts and fixed timeouts are never right. TimeoutPolicy allows users to set policy (like 2.5 sigma) instead of fixed timeout values and takes care of the heuristics by itself allowing systems to adapt to their operating conditions.
   3. Spray doesn't have friendly API for Java, the spray.japi package provides a few of Helpers and Factories to help Java developers to construct spray entities easily.
+  4. Validation provides a [Spray](http://spray.io) directive for data validation by using [Accord Validation Library](http://wix.github.io/accord/).
 
 6. **ActorRegistry**: A core lookup facility allowing actors of loosely-coupled modules to find each others, or even to model different services as actors.
 
@@ -49,6 +50,7 @@ TODO: Reference to template projects
 * [Using the Orchestration DSL](docs/orchestration_dsl.md)
 * [The ActorRegistry](docs/registry.md)
 * [Timeout Policy](docs/timeoutpolicy.md)
+* [Validation](docs/validation.md)
 
 ##Contributing to squbs
 Thank you very much for contributing to squbs. Please read the [contribution guidelines](CONTRIBUTING.md) for the process.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,69 @@
+#Validation
+
+squbs Validation provides a [Spray](http://spray.io) directive for data validation by using [Accord Validation Library](http://wix.github.io/accord/).
+  
+##Usage
+  
+Given that an implicit `Person` validator is in the scope, `validate` directive can be used as other [Spray Directives](http://spray.io/documentation/1.2.3/spray-routing/key-concepts/directives/):     
+  
+```
+import ValidationDirectives._
+validate(person) { 
+    ...
+}
+```  
+
+##Example
+
+Here is a sample `Person` class and corresponding validator (please see [Accord Validation Library](http://wix.github.io/accord/) for more validator usage examples).
+
+```
+case class Person(firstName: String, lastName: String, middleName: Option[String] = None, age: Int)
+
+object SampleValidators {
+
+  import com.wix.accord.dsl._
+  implicit val personValidator = com.wix.accord.dsl.validator[ Person ] { p =>
+                p.firstName as "First Name" is notEmpty
+                p.lastName as "Last Name" is notEmpty
+                p.middleName.each is notEmpty // If exists, should not be empty.
+                p.age should be >= 0
+              }
+}
+```
+
+Now you can use the `validate` directive as follows: 
+ 
+ ```
+ def route =
+     path("person") {
+       post {
+         entity(as[Person]) { person =>
+           import ValidationDirectives._
+           validate(person) {
+             respondWithMediaType(`application/json`) {
+               complete {
+                 person
+               }
+             }
+           }
+         }
+       }
+     }
+ ```
+ 
+If a validation rejection happens, a `400 Bad Request` is returned with the response body containing the comma separated list of field(s) causing validation rejection.  Using the above example, if the request body contains the following:
+  
+```
+{
+    "firstName" : "John",
+    "lastName" : "",
+    "age" : -1
+}
+```
+ 
+then, the response body would contain:
+  
+```
+Last Name, age 
+```

--- a/squbs-pattern/build.sbt
+++ b/squbs-pattern/build.sbt
@@ -12,13 +12,18 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-contrib" % akkaV intransitive(),
   "io.spray"          %% "spray-http" % sprayV,
   "io.spray"          %% "spray-httpx" % sprayV,
+  "io.spray" %% "spray-routing" % sprayV,
+  "io.spray" %% "spray-testkit" % sprayV % "test",
+  "io.spray" %% "spray-httpx" % sprayV % "test",
+  "io.spray" %% "spray-json" % sprayV % "test",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
   "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test->*",
   "junit" % "junit" % "4.12" % "test",
   "org.apache.commons"         %  "commons-math3"       % "3.3"   % "test->*",
   "org.scala-lang.modules"     %% "scala-java8-compat"  % "0.4.0" % "test",
-  "com.novocode" % "junit-interface" % "0.11" % "test->default"
+  "com.novocode" % "junit-interface" % "0.11" % "test->default",
+  "com.wix" %% "accord-core" % "0.5"
 )
 
 // : Seq[sbt.Def.Setting[_]] in the line below is not required for a successful build

--- a/squbs-pattern/src/main/scala/org/squbs/pattern/validation/ValidationDirectives.scala
+++ b/squbs-pattern/src/main/scala/org/squbs/pattern/validation/ValidationDirectives.scala
@@ -1,0 +1,34 @@
+package org.squbs.pattern.validation
+
+import com.wix.accord.Validator
+import spray.routing.Directives._
+import spray.routing._
+
+trait ValidationDirectives {
+  def validate(magnet: ValidationMagnet) = magnet()
+}
+
+// Later on we can rename it to squbsDirectives, when we have more maybe ?
+object ValidationDirectives extends ValidationDirectives
+
+/**
+ * @see <a href="http://spray.io/blog/2012-12-13-the-magnet-pattern">Magnet Pattern</a>
+ */
+sealed trait ValidationMagnet {
+  def apply(): Directive0
+}
+
+object ValidationMagnet {
+  implicit def fromObj[T](obj: T)(implicit validator: Validator[ T ]) =
+    new ValidationMagnet {
+      def apply() = {
+
+        val result = com.wix.accord.validate(obj)
+
+        result match {
+          case com.wix.accord.Success => pass
+          case com.wix.accord.Failure(violations) => reject(ValidationRejection(violations flatMap {violation => violation.description} mkString(", ")))
+        }
+      }
+    }
+}

--- a/squbs-pattern/src/test/scala/org/squbs/pattern/validation/Person.scala
+++ b/squbs-pattern/src/test/scala/org/squbs/pattern/validation/Person.scala
@@ -1,0 +1,14 @@
+package org.squbs.pattern.validation
+
+case class Person(firstName: String, lastName: String, middleName: Option[String] = None, age: Int)
+
+object SampleValidators {
+
+  import com.wix.accord.dsl._
+  implicit val personValidator = com.wix.accord.dsl.validator[ Person ] { p =>
+                p.firstName as "First Name" is notEmpty
+                p.lastName as "Last Name" is notEmpty
+                p.middleName.each is notEmpty // If exists, should not be empty.
+                p.age should be >= 0
+              }
+}

--- a/squbs-pattern/src/test/scala/org/squbs/pattern/validation/ValidationDirectivesTest.scala
+++ b/squbs-pattern/src/test/scala/org/squbs/pattern/validation/ValidationDirectivesTest.scala
@@ -1,0 +1,78 @@
+package org.squbs.pattern.validation
+
+import org.scalatest.{FlatSpecLike, Matchers}
+import org.squbs.pattern.validation.SampleValidators._
+import spray.http.MediaTypes._
+import spray.http._
+import spray.httpx.SprayJsonSupport._
+import spray.httpx.marshalling._
+import spray.json.DefaultJsonProtocol
+import spray.routing.Directives._
+import spray.routing.ValidationRejection
+import spray.routing.directives.MarshallingDirectives
+import spray.testkit.ScalatestRouteTest
+
+object MyJsonProtocol extends DefaultJsonProtocol {
+  implicit val PersonFormat = DefaultJsonProtocol.jsonFormat4(Person)
+}
+
+class ValidationDirectivesTest extends FlatSpecLike with Matchers with ScalatestRouteTest {
+
+  val validData1 = Person("John", "Smith", age = 25)
+  val validData2 = Person("John", "Smith", Some("Mike"), age = 25)
+
+  val invalidData1 = Person("John", "", age = 25)
+  val invalidData2 = Person("John", "Smith", Some(""), age = 25)
+  val invalidData3 = Person("John", "", Some(""), age = -1)
+
+  import MyJsonProtocol._
+
+  val route =
+    path("person") {
+      post {
+        MarshallingDirectives.entity(as[Person]) { person =>
+          import ValidationDirectives._
+          validate(person) {
+            respondWithMediaType(`application/json`) {
+              complete {
+                person
+              }
+            }
+          }
+        }
+      }
+    }
+
+
+  it should "return the same object with 200 for a valid content without middle name" in {
+    Post("/person", validData1) ~> route ~> check {
+      status shouldEqual StatusCodes.OK
+      Right(body) shouldEqual marshal(validData1)
+    }
+  }
+
+  it should "return the same object with 200 for a valid content with middle name" in {
+    Post("/person", validData2) ~> route ~> check {
+      status shouldEqual StatusCodes.OK
+      Right(body) shouldEqual marshal(validData2)
+    }
+  }
+
+  it should "reject with Last Name" in {
+    Post("/person", invalidData1) ~> route ~> check {
+      rejections shouldEqual List(ValidationRejection("Last Name"))
+    }
+  }
+
+  it should "reject with middleName" in {
+    Post("/person", invalidData2) ~> route ~> check {
+      rejections shouldEqual List(ValidationRejection("middleName"))
+    }
+  }
+
+  it should "reject with Last Name, middleName, age" in {
+    Post("/person", invalidData3) ~> route ~> check {
+      rejections shouldEqual List(ValidationRejection("Last Name, middleName, age"))
+    }
+  }
+}


### PR DESCRIPTION
Adding `validate` Spray Directive for data validation.

* Validation directive uses [Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/).
* Actual validation is done via [Accord Validation Library](http://wix.github.io/accord/) version 0.5.