### PR TITLE
#72: Optimized HttpClientManager Uri.Path usage

### DIFF
--- a/squbs-httpclient/src/main/scala/org/squbs/httpclient/HttpClientJMX.scala
+++ b/squbs-httpclient/src/main/scala/org/squbs/httpclient/HttpClientJMX.scala
@@ -102,7 +102,7 @@ case class HttpClientBean(system: ActorSystem) extends HttpClientMXBean {
   private def mapToHttpClientInfo(httpClient: HttpClient) = {
     val name = httpClient.name
     val env  = httpClient.env.lowercaseName
-    val endpoint = httpClient.endpoint.uri
+    val endpoint = httpClient.endpoint.uri.toString()
     val status = httpClient.status.toString
     val configuration = httpClient.endpoint.config
     val pipelines = configuration.pipeline.getOrElse(PipelineSetting.default).pipelineConfig

--- a/squbs-httpclient/src/main/scala/org/squbs/httpclient/endpoint/HttpClientEndpoint.scala
+++ b/squbs-httpclient/src/main/scala/org/squbs/httpclient/endpoint/HttpClientEndpoint.scala
@@ -18,13 +18,14 @@ package org.squbs.httpclient.endpoint
 
 import akka.actor.{ActorSystem, ExtensionId, Extension, ExtendedActorSystem}
 import org.squbs.pipeline.{PipelineManager, PipelineSetting}
+import spray.http.Uri
 
 import scala.collection.mutable.ListBuffer
 import org.squbs.httpclient.env.{Default, Environment}
 import org.squbs.httpclient.Configuration
 import com.typesafe.scalalogging.LazyLogging
 
-case class Endpoint(uri: String, config: Configuration = Configuration())
+case class Endpoint(uri: Uri, config: Configuration = Configuration())
 
 object Endpoint {
 

--- a/squbs-httpclient/src/main/scala/org/squbs/httpclient/pipeline/HttpClientPipeline.scala
+++ b/squbs-httpclient/src/main/scala/org/squbs/httpclient/pipeline/HttpClientPipeline.scala
@@ -27,7 +27,7 @@ import org.squbs.httpclient.endpoint.Endpoint
 import org.squbs.httpclient.pipeline.impl.RequestUpdateHeadersHandler
 import org.squbs.pipeline.PipelineSetting
 import spray.can.Http
-import spray.http.{HttpRequest, HttpResponse, Uri}
+import spray.http.{HttpRequest, HttpResponse}
 import spray.httpx.unmarshalling._
 import spray.httpx.{PipelineException, UnsuccessfulResponseException}
 import spray.io.ClientSSLEngineProvider
@@ -67,7 +67,7 @@ trait PipelineManager extends LazyLogging {
     implicit val myClientEngineProvider = ClientSSLEngineProvider { engine =>
       engine
     }
-    val uri = Uri(client.endpoint.uri)
+    import client.endpoint.uri
     val host = uri.authority.host.toString
     val port = if (uri.effectivePort == 0) 80 else uri.effectivePort
     val isSecure = uri.scheme.toLowerCase.equals("https")
@@ -114,7 +114,7 @@ trait PipelineManager extends LazyLogging {
   }
 
   implicit def endpointToUri(endpoint: Endpoint): String = {
-    val uri = Uri(endpoint.uri)
+    val uri = endpoint.uri
     val host = uri.authority.host.toString
     val port = if (uri.effectivePort == 0) 80 else uri.effectivePort
     val isSecure = uri.scheme.toLowerCase.equals("https")

--- a/squbs-httpclient/src/test/scala/org/squbs/httpclient/HttpClientManagerSpec.scala
+++ b/squbs-httpclient/src/test/scala/org/squbs/httpclient/HttpClientManagerSpec.scala
@@ -20,6 +20,7 @@ import akka.actor.Status.Failure
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.squbs.httpclient.Configuration._
 import org.squbs.httpclient.HttpClientActorMessage.{MarkDownSuccess, MarkUpSuccess}
 import org.squbs.httpclient.HttpClientManagerMessage.{Delete, Get, _}
 import org.squbs.httpclient.dummy.DummyService._
@@ -30,11 +31,10 @@ import org.squbs.httpclient.pipeline.HttpClientUnmarshal
 import org.squbs.pipeline.PipelineSetting
 import spray.http.{HttpResponse, StatusCodes}
 import spray.httpx.SprayJsonSupport
-import spray.json.{RootJsonFormat, DefaultJsonProtocol}
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Success
-import Configuration._
 
 class HttpClientManagerSpec extends TestKit(ActorSystem("HttpClientManagerSpec")) with FlatSpecLike
     with HttpClientTestKit with Matchers with ImplicitSender with BeforeAndAfterAll with DummyService{
@@ -50,6 +50,17 @@ class HttpClientManagerSpec extends TestKit(ActorSystem("HttpClientManagerSpec")
   override def afterAll() {
     clearHttpClient()
     shutdownActorSystem()
+  }
+
+  "Path end check" should "return correct results" in {
+    import spray.http.Uri.Path
+    import HttpClientManager._
+    Path("/foo/bar/").endsWithSlash shouldBe true
+    Path("/foo/bar").endsWithSlash shouldBe false
+    Path("foo/bar").endsWithSlash shouldBe false
+    Path("foo/").endsWithSlash shouldBe true
+    Path("/").endsWithSlash shouldBe true
+    Path("").endsWithSlash shouldBe false
   }
 
   "httpClientMap" should "be empty before creating any http clients" in {

--- a/squbs-httpclient/src/test/scala/org/squbs/httpclient/HttpClientSpec.scala
+++ b/squbs-httpclient/src/test/scala/org/squbs/httpclient/HttpClientSpec.scala
@@ -314,7 +314,7 @@ class HttpClientSpec extends TestKit(ActorSystem("HttpClientSpec")) with FlatSpe
 
   "HttpClient could use endpoint as service name directly without registering endpoint resolvers for " +
         "third party service call" should "get the correct response" in {
-    val response: Future[HttpResponse] = HttpClientFactory.get(dummyServiceEndpoint).raw.get("/view")
+    val response: Future[HttpResponse] = HttpClientFactory.get(dummyServiceEndpoint.toString()).raw.get("/view")
     val result = Await.result(response, awaitMax)
     result.status should be (StatusCodes.OK)
     result.entity should not be empty
@@ -344,7 +344,7 @@ class HttpClientSpec extends TestKit(ActorSystem("HttpClientSpec")) with FlatSpe
     val httpClient = HttpClientFactory.get("DummyService")
     val pipeline = Some(DummyRequestPipeline)
     val pipelineSetting : Option[PipelineSetting] = pipeline
-    val updatedHttpClient = httpClient.withPipeline(pipeline)
+    val updatedHttpClient = httpClient.withPipelineSetting(Some(PipelineSetting(config = pipeline)))
     EndpointRegistry(system).resolve("DummyService") should be (Some(Endpoint(dummyServiceEndpoint)))
     updatedHttpClient.endpoint.config.pipeline should be (pipelineSetting)
   }

--- a/squbs-httpclient/src/test/scala/org/squbs/httpclient/dummy/DummyService.scala
+++ b/squbs-httpclient/src/test/scala/org/squbs/httpclient/dummy/DummyService.scala
@@ -87,7 +87,7 @@ object DummyService {
 
   val (dummyServiceIpAddress, dummyServicePort) = temporaryServerHostnameAndPort()
 
-  val dummyServiceEndpoint = s"http://$dummyServiceIpAddress:$dummyServicePort"
+  val dummyServiceEndpoint = Uri(s"http://$dummyServiceIpAddress:$dummyServicePort")
 }
 
 object DummyServiceMain extends App with DummyService {

--- a/squbs-httpclient/src/test/scala/org/squbs/httpclient/japi/HttpClientJSpec.scala
+++ b/squbs-httpclient/src/test/scala/org/squbs/httpclient/japi/HttpClientJSpec.scala
@@ -342,7 +342,7 @@ class HttpClientJSpec extends TestKit(ActorSystem("HttpClientJSpec")) with FlatS
   "HttpClient could use endpoint as service name directly without registering endpoint resolvers for " +
         "third party service call" should "get the correct response" in {
     //val response: Future[HttpResponse] = HttpClientFactory.get(dummyServiceEndpoint).raw.get("/view")
-    val response = HttpClientJ.rawGet(dummyServiceEndpoint, system, "/view")
+    val response = HttpClientJ.rawGet(dummyServiceEndpoint.toString(), system, "/view")
     val result = Await.result(response, awaitMax)
     result.status should be (StatusCodes.OK)
     result.entity should not be empty

--- a/squbs-pipeline/src/main/scala/org/squbs/pipeline/PipelineManager.scala
+++ b/squbs-pipeline/src/main/scala/org/squbs/pipeline/PipelineManager.scala
@@ -35,7 +35,7 @@ case class PipelineManager(configs: Map[String, RawPipelineSetting], pipelines: 
     get(name) match {
       case Some(Left(v)) => v
       case Some(Right(v)) => v.factory.create(v.pipelineConfig, v.setting)
-      case None if (name.equals("default-proxy")) => None
+      case None if name.equals("default-proxy") => None
       case None => throw new IllegalArgumentException(s"No registered squbs.proxy found with name: $name")
     }
   }


### PR DESCRIPTION
Renamed verifyUri to makeFullUri as it fits the intent of the function better.