### PR TITLE
#176 squbs-admin-exp Admin Console on Akka Http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,8 @@ lazy val `squbs-actormonitor` = project dependsOn (`squbs-unicomplex`, `squbs-te
 
 lazy val `squbs-admin` = project dependsOn (`squbs-unicomplex`, `squbs-testkit` % "test")
 
+lazy val `squbs-admin-exp` = project dependsOn (`squbs-unicomplex`, `squbs-testkit` % "test")
+
 publishTo in ThisBuild := {
   val nexus = "https://oss.sonatype.org/"
   if (version.value.trim.endsWith("SNAPSHOT"))

--- a/squbs-admin-exp/NOTICE.txt
+++ b/squbs-admin-exp/NOTICE.txt
@@ -1,0 +1,107 @@
+Acknowledgment is made of the following third party components used in Squbs Admin
+
+Scala
+Copyright (c) 2002-2014 EPFL
+Copyright (c) 2011-2014 Typesafe, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of the EPFL nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS �AS IS� AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*******************************************************
+
+ScalaTest
+Copyright 2001-2013 Artima, Inc.
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+*******************************************************
+
+Akka
+Copyright 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*******************************************************
+
+Spray
+Copyright � 2011-2013 the spray project <http://spray.io>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/squbs-admin-exp/build.sbt
+++ b/squbs-admin-exp/build.sbt
@@ -1,0 +1,22 @@
+import Versions._
+
+name := "squbs-admin-exp"
+
+Revolver.settings
+
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test->*",
+  "com.typesafe.akka" %% "akka-actor" % akkaV,
+  "com.typesafe.akka" %% "akka-agent" % akkaV,
+  "com.typesafe.akka" %% "akka-http-experimental" % akkaV,
+  "com.typesafe.akka" %% "akka-http-testkit" % akkaV % "test",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
+  "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
+  "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
+  "org.json4s" %% "json4s-jackson" % "3.3.0"
+)
+
+(testOptions in Test) += Tests.Argument(TestFrameworks.ScalaTest, "-h", "report/squbs-unicomplex")
+
+mainClass in (Compile, run) := Some("org.squbs.unicomplex.Bootstrap")

--- a/squbs-admin-exp/findbugsExclude.xml
+++ b/squbs-admin-exp/findbugsExclude.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+
+<!--
+  ~  Copyright 2015 PayPal
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<FindBugsFilter>
+	
+	<!-- This is to ignore the immutable field error -->
+	<Match>
+       <Bug code="EI,EI2" />
+     </Match>
+     
+     <Match>
+     	<Bug pattern="SA_LOCAL_SELF_ASSIGNMENT,SE_BAD_FIELD" />
+     </Match>
+     
+     <!-- ConfigWeb project will be removed from Raptor and hence removing it from analysis -->
+     <Match>
+       <Package name="~com.ebay.raptor.configweb.*.*" />
+     </Match>
+     <Match>
+       <Package name=".*/raptor/configweb/.*" />
+     </Match>
+     <Match>
+       <Class name="~.*Test$"/>
+     </Match>
+     <Match>
+       <Package name="~test\..*"/>
+     </Match>
+
+     <Match>
+       <Package name="~tests\..*"/>
+     </Match>
+ 
+     <Match>
+     	<Package name="~com.ebay.content.srp_raptor.*"/>
+     </Match>
+     
+     <!-- Need to exclude as it uses a hardcoded password for code collaborator -->
+     <Match>
+       <Class name="~com.ebay.raptor.test.util.CodeCollaboratorUtil" />
+     </Match>
+     
+     <!-- Need to exclude as it uses a hardcoded password for code collaborator -->
+     <Match>
+       <Class name="~com.ebay.content.srp_raptor.SearchResultsContent" />
+     </Match>
+     
+     <!-- These fields are final but still findbugs produce warnings on these -->
+     <Match>
+     	<Class name="~com.ebay.raptor.kernel.util.XssCheckUtil"/>
+     	<Field name="ILLEGAL_TAGS_FOR_STRINGS"/>
+     	<Bug code="MS"/>
+     </Match>
+     <Match>
+     	<Class name="~com.ebay.raptor.kernel.util.XssCheckUtil"/>
+     	<Field name="ILLEGAL_TAGS_FOR_URLS"/>
+     	<Bug code="MS"/>
+     </Match>
+
+</FindBugsFilter>

--- a/squbs-admin-exp/src/main/resources/META-INF/squbs-meta.conf
+++ b/squbs-admin-exp/src/main/resources/META-INF/squbs-meta.conf
@@ -1,0 +1,11 @@
+cube-name = org.squbs.admin
+
+cube-version = "0.7.1"
+squbs-services = [
+  {
+    class-name = org.squbs.admin.AdminSvc
+    listeners = [ admin-listener ]
+    web-context = adm
+    defaultPipelineOn = false
+  }
+]

--- a/squbs-admin-exp/src/main/scala/org/squbs/admin/AdminSvc.scala
+++ b/squbs-admin-exp/src/main/scala/org/squbs/admin/AdminSvc.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.squbs.admin
+
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model._
+import org.json4s.JsonAST.{JString, JObject}
+import org.json4s.jackson.JsonMethods._
+import org.squbs.unicomplex.streaming.RouteDefinition
+import org.squbs.unicomplex.{ConfigUtil, WebContext}
+import ConfigUtil._
+
+class AdminSvc extends RouteDefinition with WebContext {
+
+  val prefix = if (webContext == "") "/bean" else s"/$webContext/bean"
+
+  val exclusions = context.system.settings.config.getOptionalStringList("squbs.admin.exclusions")
+  val (exBeans, exFieldSet) = exclusions map { list =>
+    val (beans, fields) = list partition { x => x.indexOf("::") < 0 }
+    (beans.toSet, fields.toSet)
+  } getOrElse (Set.empty[String], Set.empty[String])
+
+  val exFields = exFieldSet map { fieldSpec =>
+    val fields = fieldSpec split "::"
+    fields(0) -> fields(1)
+  } groupBy (_._1) mapValues { _.map(_._2) }
+
+
+  val route =
+    get {
+      pathEndOrSingleSlash {
+        extractUri { uri =>
+          complete {
+            val kv = MBeanUtil.allObjectNames collect {
+              case name if !(exBeans contains name) =>
+                val resource = Path(s"$prefix/${name.replace('=', '~')}")
+                name -> JString(uri.withPath(resource).toString())
+            }
+            HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, pretty(render(JObject(kv)))))
+          }
+        }
+      } ~
+      path("bean" / Segment) { encName =>
+        complete {
+          val name = encName.replace('~', '=').replace('%', '/')
+          val response: HttpResponse =
+            if (exBeans contains name) HttpResponse(StatusCodes.NotFound, entity = StatusCodes.NotFound.defaultMessage)
+            else MBeanUtil.asJSON(name, exFields getOrElse (name, Set.empty))
+              .map { json => HttpResponse(entity = json) }
+              .getOrElse (HttpResponse(StatusCodes.NotFound, entity = StatusCodes.NotFound.defaultMessage))
+          response
+        }
+      }
+    }
+}

--- a/squbs-admin-exp/src/main/scala/org/squbs/admin/MBeanUtil.scala
+++ b/squbs-admin-exp/src/main/scala/org/squbs/admin/MBeanUtil.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.admin
+
+import java.lang.management.ManagementFactory
+import javax.management.{InstanceNotFoundException, ObjectName}
+import javax.management.openmbean.{CompositeData, TabularData}
+
+import com.fasterxml.jackson.core.util.{DefaultPrettyPrinter, DefaultIndenter}
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import scala.collection.JavaConversions._
+import scala.util.Try
+
+object MBeanUtil {
+
+  val server = ManagementFactory.getPlatformMBeanServer
+
+  def allObjectNames: List[String] = {
+    val beans = server.queryMBeans(null, null)
+    beans.map { bean =>
+      bean.getObjectName.toString
+    } .toList.sorted
+  }
+
+  def asJSON(beanName: String, exclusions: Set[String] = Set.empty): Option[String] = {
+    val objectName = new ObjectName(beanName)
+    val c = new MBean2JSON(exclusions)
+    try {
+      val fields = server.getMBeanInfo(objectName).getAttributes.toList.map { _.getName}.sorted.collect {
+        case name if !(exclusions contains name) => name -> c.eval {
+          server.getAttribute(objectName, name)
+        }
+      }
+      Option(prettyPrint(render(fields)))
+    } catch {
+      case e: InstanceNotFoundException => None
+    }
+  }
+
+  private def prettyPrint(v: JValue) = {
+    val printer = new DefaultPrettyPrinter().withArrayIndenter(new DefaultIndenter)
+    mapper.writer(printer).writeValueAsString(v)
+  }
+
+  class MBean2JSON(exclusions: Set[String]) {
+
+    private def toJValue(valueOption: Option[Any]): JValue = valueOption match {
+      case Some(value) => value match {
+        case table: TabularData =>
+          val list = table.values.toArray
+          optionJObject(list) getOrElse {
+            toJArray(list)
+          }
+        case list: Array[_] => optionJObject(list) getOrElse {
+          toJArray(list)
+        }
+        case c: CompositeData => toJObject(c)
+        case v: java.lang.Double => v.doubleValue
+        case v: java.lang.Float => v.floatValue
+        case v: java.lang.Number => v.longValue
+        case v: java.lang.Boolean => v.booleanValue
+        case v => v.toString
+      }
+      case None => JNull
+    }
+
+    private def toJArray(list: Array[_]) = JArray(list.toList map { v => toJValue(Option(v)) })
+
+    private def optionJObject(list: Array[_]) = {
+      try {
+        val kc = list.map {
+          case c: CompositeData =>
+            val keySet = c.getCompositeType.keySet
+            if (keySet.size == 2 && keySet.contains("key") && keySet.contains("value"))
+              c.get("key").asInstanceOf[String] -> c
+            else throw new ClassCastException("CompositeData member is not a key/value pair")
+          case _ => throw new ClassCastException("Non-CompositeData value")
+        }
+        val fields = kc.toList collect {
+          case (k, c) if !(exclusions contains k) => k -> eval { c.get("value") }
+        }
+        Some(JObject(fields))
+      } catch {
+        case e: ClassCastException => None
+      }
+    }
+
+    private def toJObject(c: CompositeData) =
+      JObject(c.getCompositeType.keySet.toList.sorted collect {
+        case key if !(exclusions contains key) => key -> eval { c.get(key)}
+      })
+
+    // Note: Try {...} .toOption can give you a Some(null), especially with Java APIs.
+    // Need to flatMap with Option again to ensure Some(null) is None.
+    def eval(fn: => Any) = toJValue(Try { fn } .toOption flatMap { v => Option(v) })
+  }
+}

--- a/squbs-admin-exp/src/test/scala/org/squbs/admin/AdminSvcTest.scala
+++ b/squbs-admin-exp/src/test/scala/org/squbs/admin/AdminSvcTest.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.admin
+
+import java.lang.management.ManagementFactory
+import javax.management.{ObjectName, MXBean}
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{FunSpecLike, Matchers}
+import org.squbs.testkit.streaming.TestRoute
+
+import scala.beans.BeanProperty
+
+class AdminSvcTest extends FunSpecLike with Matchers with ScalatestRouteTest {
+
+  ManagementFactory.getPlatformMBeanServer.registerMBean(SlashTestBean("foo"),
+    new ObjectName("org.squbs.admin.test:type=SlashTestBean/FooBean"))
+
+
+  describe ("The AdminSvc route with root web context") {
+
+    val route = TestRoute[AdminSvc]
+
+    it ("should provide the MBean list for root request") {
+      Get("/") ~> route ~> check {
+        val response = responseAs[String]
+        noException should be thrownBy parse(response)
+        response should include (""""java.lang:type=Runtime" : """)
+        response should include (""""java.lang:type=OperatingSystem" :""")
+        response should include (""""org.squbs.admin.test:type=SlashTestBean/FooBean" :""")
+      }
+    }
+
+    it ("should provide proper JSON in response") {
+      Get("/bean/java.lang:type~OperatingSystem") ~> route ~> check {
+        noException should be thrownBy parse(responseAs[String])
+      }
+    }
+
+    it ("should provide proper JSON in response to bean with slashes in name") {
+      Get("/bean/org.squbs.admin.test:type~SlashTestBean%25FooBean") ~> route ~> check {
+        noException should be thrownBy parse(responseAs[String])
+      }
+    }
+
+    it ("should return status NotFound accessing an invalid bean name") {
+      Get("/bean/java.lang:type~FooBar") ~> route ~> check {
+        response.status shouldBe StatusCodes.NotFound
+      }
+    }
+  }
+
+  describe ("The AdminSvc route with adm web context") {
+
+    val route = TestRoute[AdminSvc](webContext = "adm")
+
+    it ("should provide the MBean list for root request") {
+      Get("/adm") ~> route ~> check {
+        val response = responseAs[String]
+        noException should be thrownBy parse(response)
+        response should include (""""java.lang:type=Runtime" : """)
+        response should include (""""java.lang:type=OperatingSystem" :""")
+        response should include (""""org.squbs.admin.test:type=SlashTestBean/FooBean" :""")
+      }
+    }
+
+    it ("should provide proper JSON in response") {
+      Get("/adm/bean/java.lang:type~OperatingSystem") ~> route ~> check {
+        noException should be thrownBy parse(responseAs[String])
+      }
+    }
+
+    it ("should provide proper JSON in response to bean with slashes in name") {
+      Get("/adm/bean/org.squbs.admin.test:type~SlashTestBean%25FooBean") ~> route ~> check {
+        noException should be thrownBy parse(responseAs[String])
+      }
+    }
+
+    it ("should return status NotFound accessing an invalid bean name") {
+      Get("/adm/bean/java.lang:type~FooBar") ~> route ~> check {
+        response.status shouldBe StatusCodes.NotFound
+      }
+    }
+  }
+}
+
+class AdminSvcWithExclusionTest extends FunSpecLike with Matchers with ScalatestRouteTest {
+
+  override def testConfigSource = """
+      |squbs.admin {
+      |  exclusions = [ "java.lang:type=Memory", "java.lang:type=GarbageCollector,name=PS MarkSweep::init" ]
+      |}
+    """.stripMargin
+
+
+  describe ("The AdminSvc route with root web context") {
+
+    val route = TestRoute[AdminSvc]
+
+    it ("should provide the MBean list for root request") {
+      Get("/") ~> route ~> check {
+        val response = responseAs[String]
+        noException should be thrownBy parse(response)
+        response should include (""""java.lang:type=Runtime" : """)
+        response should include (""""java.lang:type=OperatingSystem" :""")
+        response should not include """"java.lang:type=Memory" :"""
+      }
+    }
+
+    it ("should provide proper JSON with correct field exclusions in response") {
+      Get("/bean/java.lang:type~GarbageCollector,name~PS%20MarkSweep") ~> route ~> check {
+        val json = responseAs[String]
+        noException should be thrownBy parse(json)
+        json should not include """"init" :"""
+      }
+    }
+
+    it ("should return status NotFound accessing an excluded bean") {
+      Get("/bean/java.lang:type~Memory") ~> route ~> check {
+        response.status shouldBe StatusCodes.NotFound
+      }
+    }
+  }
+
+  describe ("The AdminSvc route with adm web context") {
+
+    val route = TestRoute[AdminSvc](webContext = "adm")
+
+    it ("should provide the MBean list for root request") {
+      Get("/adm") ~> route ~> check {
+        val response = responseAs[String]
+        noException should be thrownBy parse(response)
+        response should include (""""java.lang:type=Runtime" : """)
+        response should include (""""java.lang:type=OperatingSystem" :""")
+        response should not include """"java.lang:type=Memory" :"""
+      }
+    }
+
+    it ("should provide proper JSON  with correct field exclusions in response") {
+      Get("/adm/bean/java.lang:type~OperatingSystem") ~> route ~> check {
+        val json = responseAs[String]
+        noException should be thrownBy parse(json)
+        json should not include """"init" :"""
+      }
+    }
+
+    it ("should return status NotFound accessing an excluded bean") {
+      Get("/adm/bean/java.lang:type~Memory") ~> route ~> check {
+        response.status shouldBe StatusCodes.NotFound
+      }
+    }
+  }
+}
+
+@MXBean
+trait SlashTestMxBean {
+  def getProp: String
+}
+
+case class SlashTestBean(@BeanProperty prop: String) extends SlashTestMxBean

--- a/squbs-admin-exp/src/test/scala/org/squbs/admin/MBeanUtilTest.scala
+++ b/squbs-admin-exp/src/test/scala/org/squbs/admin/MBeanUtilTest.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.admin
+
+import java.beans.ConstructorProperties
+import java.lang.management.ManagementFactory
+import javax.management.{MXBean, ObjectName}
+
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest._
+
+import scala.beans.{BeanProperty, BooleanBeanProperty}
+import scala.collection.JavaConversions._
+
+class MBeanUtilTest extends FunSpecLike with Matchers with BeforeAndAfterAll with Inspectors with OptionValues {
+
+  override def beforeAll() {
+
+    val testBean = TestBean("Hello", 123.456, Long.MaxValue, props03 = false,
+      AnotherTestObject("Hi TestObject", props1 = true), Array(1.0f, 1.5f, 2.0f, 2.5f), Array(true, false, false, true),
+      Array("foo", "bar", "foobar", "baz"), Array(AnotherTestObject("Hi TestObject1", props1 = true),
+        AnotherTestObject("Hi TestObject2", props1 = false)), Array(KeyValueObject("foo", "bar"),
+        KeyValueObject("foobar", "baz")),
+      Map("foo" -> AnotherTestObject("Hi TestObject3", props1 = false),
+        "bar" -> AnotherTestObject("Hi TestObject4", props1 = true)))
+
+    ManagementFactory.getPlatformMBeanServer.registerMBean(testBean,
+      new ObjectName("org.squbs.admin.test:type=TestBean"))
+  }
+
+  override def afterAll(): Unit = {
+    ManagementFactory.getPlatformMBeanServer.unregisterMBean(new ObjectName("org.squbs.admin.test:type=TestBean"))
+  }
+
+  it ("should render TestMXBean with proper indentation.") {
+    val expectedJSON =
+      """{
+        |  "Props00" : "Hello",
+        |  "Props01" : 123.456,
+        |  "Props02" : 9223372036854775807,
+        |  "Props03" : false,
+        |  "Props04" : {
+        |    "props0" : "Hi TestObject",
+        |    "props1" : true
+        |  },
+        |  "Props05" : [
+        |    1.0,
+        |    1.5,
+        |    2.0,
+        |    2.5
+        |  ],
+        |  "Props06" : [
+        |    true,
+        |    false,
+        |    false,
+        |    true
+        |  ],
+        |  "Props07" : [
+        |    "foo",
+        |    "bar",
+        |    "foobar",
+        |    "baz"
+        |  ],
+        |  "Props08" : [
+        |    {
+        |      "props0" : "Hi TestObject1",
+        |      "props1" : true
+        |    },
+        |    {
+        |      "props0" : "Hi TestObject2",
+        |      "props1" : false
+        |    }
+        |  ],
+        |  "Props09" : {
+        |    "foo" : "bar",
+        |    "foobar" : "baz"
+        |  },
+        |  "Props10" : {
+        |    "foo" : {
+        |      "props0" : "Hi TestObject3",
+        |      "props1" : false
+        |    },
+        |    "bar" : {
+        |      "props0" : "Hi TestObject4",
+        |      "props1" : true
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val testBeanJSON = MBeanUtil.asJSON("org.squbs.admin.test:type=TestBean").value
+    println(testBeanJSON)
+    testBeanJSON shouldBe expectedJSON
+  }
+
+  it ("should render TestMXBean while skipping exclusions") {
+    val testBeanJSON = MBeanUtil.asJSON("org.squbs.admin.test:type=TestBean", Set("props1", "Props09")).value
+    testBeanJSON should include (""""Props10" : """)
+    testBeanJSON should include (""": "Hi TestObject3"""")
+    testBeanJSON should not include """"Props09" : """
+    testBeanJSON should not include """ "props1"" : """
+  }
+
+  it ("should return None for invalid bean name") {
+    val optionJSON = MBeanUtil.asJSON("org.squbs.admin.test:type=TestBean2")
+    optionJSON should not be defined
+  }
+
+  it ("should list relevant JMX beans in the system") {
+    MBeanUtil.allObjectNames should contain allOf (
+      "org.squbs.admin.test:type=TestBean",
+      "java.lang:type=Runtime",
+      "java.lang:type=OperatingSystem")
+  }
+
+  it ("should provide valid JSON for all JMX beans in the system") {
+    forAll (MBeanUtil.allObjectNames) { name =>
+      noException should be thrownBy parse(MBeanUtil.asJSON(name).value)
+    }
+  }
+}
+
+@MXBean
+trait TestMXBean {
+  def getProps00: String
+  def getProps01 : Double
+  def getProps02: Long
+  def isProps03: Boolean
+  def getProps04: AnotherTestObject
+  def getProps05: Array[Float]
+  def getProps06: Array[Boolean]
+  def getProps07: Array[String]
+  def getProps08: Array[AnotherTestObject]
+  def getProps09: Array[KeyValueObject]
+  def getProps10: java.util.Map[String, AnotherTestObject]
+}
+
+case class TestBean(@BeanProperty props00: String, @BeanProperty props01: Double, @BeanProperty props02: Long,
+                    @BooleanBeanProperty props03: Boolean, @BeanProperty props04: AnotherTestObject,
+                    @BeanProperty props05: Array[Float], @BeanProperty props06: Array[Boolean],
+                    @BeanProperty props07: Array[String], @BeanProperty props08: Array[AnotherTestObject],
+                    @BeanProperty props09: Array[KeyValueObject],
+                    @BeanProperty props10: java.util.Map[String, AnotherTestObject])
+  extends TestMXBean
+
+case class AnotherTestObject @ConstructorProperties(Array("props0", "props1"))(@BeanProperty props0: String,
+                                                                               @BooleanBeanProperty props1: Boolean)
+
+case class KeyValueObject @ConstructorProperties(Array("key", "value"))(@BeanProperty key: String,
+                                                                        @BeanProperty value: String)
+
+

--- a/squbs-testkit/src/main/scala/org/squbs/testkit/streaming/TestRoute.scala
+++ b/squbs-testkit/src/main/scala/org/squbs/testkit/streaming/TestRoute.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.testkit.streaming
+
+import akka.actor.{Actor, ActorSystem}
+import akka.http.scaladsl.server.Route
+import akka.testkit.TestActorRef
+import akka.http.scaladsl.server.directives.PathDirectives._
+import org.squbs.unicomplex.WebContext
+import org.squbs.unicomplex.streaming.RouteDefinition
+
+import scala.reflect.ClassTag
+
+/**
+ * The TestRoute is used for creating a Route to be used with the Akka Http TestKit, from a RouteDefinition.
+ * While a RouteDefinition is easy to define, it is actually not easy to instantiate.
+ */
+object TestRoute {
+
+  /**
+   * Creates the Route to be used in Akka Http TestKit.
+   * @param system The ActorSystem. This will be supplied implicitly if using the ScalaTestRouteTest trait from Akka Http.
+   * @tparam T The RouteDefinition to be tested
+   * @return The Route to be used for testing.
+   */
+  def apply[T <: RouteDefinition: ClassTag](implicit system: ActorSystem): Route = apply[T]("")
+
+  /**
+   * Creates the Route to be used in Akka Http TestKit.
+   * @param webContext The web context to simulate
+   * @param system The ActorSystem. This will be supplied implicitly if using the ScalaTestRouteTest trait from Akka Http.
+   * @tparam T The RouteDefinition to be tested
+   * @return The Route to be used for testing.
+   */
+  def apply[T <: RouteDefinition: ClassTag](webContext: String)(implicit system: ActorSystem): Route = {
+    val clazz = implicitly[ClassTag[T]].runtimeClass
+    implicit val actorContext = TestActorRef[TestRouteActor].underlyingActor.context
+    val routeDef = WebContext.createWithContext(webContext) {
+      RouteDefinition.startRoutes {
+        clazz.asSubclass(classOf[RouteDefinition]).newInstance()
+      }
+    }
+    if (webContext.length > 0) pathPrefix(separateOnSlashes(webContext)) {routeDef.route}
+    else routeDef.route
+  }
+
+  private class TestRouteActor extends Actor {
+    def receive = {
+      case _ =>
+    }
+  }
+}


### PR DESCRIPTION
A copy paste of the squbs-admin project, except minor Akka-Http related changes (e.g., respondWithMediateType etc) and unit tests.  Once we fully move to Akka Http (and drop supporting Spray), we will copy this project over squbs-admin..