### PR TITLE
#221 Add generic methods to RichConfig

### DIFF
--- a/squbs-pattern/src/main/scala/org/squbs/pattern/stream/QueueConfig.scala
+++ b/squbs-pattern/src/main/scala/org/squbs/pattern/stream/QueueConfig.scala
@@ -17,7 +17,7 @@ package org.squbs.pattern.stream
 
 import java.io.File
 
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigMemorySize}
 import net.openhft.chronicle.queue.{RollCycle, RollCycles}
 import net.openhft.chronicle.wire.WireType
 import org.squbs.pattern.util.ConfigUtil._
@@ -30,15 +30,15 @@ object QueueConfig {
 
   def from(config: Config): QueueConfig = {
     val persistDir = new File(config getString "persist-dir")
-    val cycle = config getOptionalString "roll-cycle" map {
+    val cycle = config.getOption[String]("roll-cycle") map {
       s => RollCycles.valueOf(s.toUpperCase)
     } getOrElse defaultCycle
-    val wireType = config getOptionalString "wire-type" map {
+    val wireType = config.getOption[String]("wire-type") map {
       s => WireType.valueOf(s.toUpperCase)
     } getOrElse defaultWireType
-    val blockSize = config getOptionalMemorySize "block-size" map (_.toBytes) getOrElse defaultBlockSize
-    val indexSpacing = config getOptionalMemorySize "index-spacing" map (_.toBytes.toInt) getOrElse cycle.defaultIndexSpacing
-    val indexCount = config getOptionalInt "index-count" getOrElse cycle.defaultIndexCount
+    val blockSize = config.getOption[ConfigMemorySize]("block-size") map (_.toBytes) getOrElse defaultBlockSize
+    val indexSpacing = config.getOption[ConfigMemorySize]("index-spacing") map (_.toBytes.toInt) getOrElse cycle.defaultIndexSpacing
+    val indexCount = config.get[Int]("index-count", cycle.defaultIndexCount)
     QueueConfig(persistDir, cycle, wireType, blockSize, indexSpacing, indexCount)
   }
 }

--- a/squbs-pattern/src/test/scala/org/squbs/pattern/util/ConfigUtilSpec.scala
+++ b/squbs-pattern/src/test/scala/org/squbs/pattern/util/ConfigUtilSpec.scala
@@ -16,7 +16,7 @@
 
 package org.squbs.pattern.util
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigMemorySize}
 import org.scalatest.{FunSpecLike, Matchers}
 
 import scala.concurrent.duration._
@@ -59,64 +59,154 @@ class ConfigUtilSpec extends FunSpecLike with Matchers {
       config.getOptionalString("testConfig.str") should be (Some("foo"))
     }
 
-    it ("should get none for non-existing string config") {
+    it ("should read some existing string config by \"getOption\"") {
+      config.getOption[String]("testConfig.str") should be (Some("foo"))
+    }
+
+    it ("should get None for non-existing string config") {
       config.getOptionalString("str") should be (None)
+    }
+
+    it ("should get None for non-existing string config by \"getOption\"") {
+      config.getOption[String]("str") should be (None)
     }
 
     it ("should read some existing string list config") {
       config.getOptionalStringList("testConfig.str-list") should be (Some(Seq("foo", "bar")))
     }
 
-    it ("should get none for non-existing string list config") {
+    it ("should read some existing string list config by \"getOption\"") {
+      config.getOption[Seq[String]]("testConfig.str-list") should be (Some(Seq("foo", "bar")))
+    }
+
+    it ("should get None for non-existing string list config") {
       config.getOptionalStringList("str-list") should be (None)
+    }
+
+    it ("should get None for non-existing string list config by \"getOption\"") {
+      config.getOption[Seq[String]]("str-list") should be (None)
     }
 
     it ("should read some existing int config") {
       config.getOptionalInt("testConfig.int-num") should be (Some(10))
     }
 
-    it ("should get none for non-existing int config") {
+    it ("should read some existing int config by \"getOption\"") {
+      config.getOption[Int]("testConfig.int-num") should be (Some(10))
+    }
+
+    it ("should get None for non-existing int config") {
       config.getOptionalInt("int-num") should be (None)
+    }
+
+    it ("should get None for non-existing int config by \"getOption\"") {
+      config.getOption[Int]("int-num") should be (None)
     }
 
     it ("should read some existing boolean config") {
       config.getOptionalBoolean("testConfig.bool-val") should be (Some(true))
     }
 
-    it ("should get none for non-existing boolean config") {
+    it ("should read some existing boolean config by \"getOption\"") {
+      config.getOption[Boolean]("testConfig.bool-val") should be (Some(true))
+    }
+
+    it ("should get None for non-existing boolean config") {
       config.getOptionalBoolean("bool-val") should be (None)
+    }
+
+    it ("should get None for non-existing boolean config by \"getOption\"") {
+      config.getOption[Boolean]("bool-val") should be (None)
     }
 
     it ("should read some existing config") {
       config.getOptionalConfig("testConfig.conf") flatMap { _.getOptionalInt("num2")} should be (Some(20))
     }
 
-    it ("should get none for non-existing config") {
+    it ("should read some existing config by \"getOption\"") {
+      config.getOption[Config]("testConfig.conf") flatMap { _.getOptionalInt("num2")} should be (Some(20))
+    }
+
+    it ("should get None for non-existing config") {
       config.getOptionalConfig("conf") should be (None)
+    }
+
+    it ("should get None for non-existing config by \"getOption\"") {
+      config.getOption[Config]("conf") should be (None)
     }
 
     it ("should read some existing config list") {
       config.getOptionalConfigList("testConfig.conf-list").get should have size 2
     }
 
-    it ("should get none for non-existing config list") {
+    it ("should read some existing config list by \"getOption\"") {
+      config.getOption[Seq[Config]]("testConfig.conf-list").get should have size 2
+    }
+
+    it ("should get None for non-existing config list") {
       config.getOptionalConfigList("conf-list") should be (None)
+    }
+
+    it ("should get None for non-existing config list \"getOption\"") {
+      config.getOption[Seq[Config]]("conf-list") should be (None)
     }
 
 		it ("should get duration for existing time") {
 			config.getOptionalDuration("testConfig.timeout").get shouldEqual Duration.create(20, SECONDS)
 		}
 
-		it ("should get none for non-existing duration") {
+    it ("should get duration for existing time by \"getOption\"") {
+      config.getOption[FiniteDuration]("testConfig.timeout").get shouldEqual Duration.create(20, SECONDS)
+    }
+
+		it ("should get None for non-existing duration") {
 			config.getOptionalDuration("non-timeout") shouldBe None
 		}
+
+    it ("should get None for non-existing duration by \"getOption\"") {
+      config.getOption[FiniteDuration]("non-timeout") shouldBe None
+    }
 
     it ("should get a proper memory size") {
       config.getOptionalMemorySize("testConfig.mem-size") map (_.toBytes) shouldBe Some(4L * 1024 * 1024)
     }
 
-    it ("should get none for non-existing memory size") {
+    it ("should get a proper memory size by \"getOption\"") {
+      config.getOption[ConfigMemorySize]("testConfig.mem-size") map (_.toBytes) shouldBe Some(4L * 1024 * 1024)
+    }
+
+    it ("should get None for non-existing memory size") {
       config.getOptionalMemorySize("mem-size") shouldBe None
+    }
+
+    it ("should get None for non-existing memory size by \"getOption\"") {
+      config.getOption[ConfigMemorySize]("mem-size") shouldBe None
+    }
+
+    it ("should get default value for non-existing config string") {
+      config.get("str", "default string") shouldBe "default string"
+    }
+
+    it ("should get config value for existing config string") {
+      config.get[String]("testConfig.str", "default string") shouldBe "foo"
+    }
+
+    it ("should throw ConfigMissing exception for non existing config string") {
+      intercept[ConfigException.Missing](
+        config.get[String]("str")
+      )
+    }
+
+    it ("should throw IllegalArgumentException for unexpected type of existing config value") {
+      intercept[IllegalArgumentException](
+        config.get[Unit]("testConfig.str")
+      )
+    }
+
+    it ("should throw WrongType exception for incorrect type of existing config value") {
+      intercept[ConfigException.WrongType](
+        config.get[Int]("testConfig.str")
+      )
     }
 
     it ("should get provide at least one IPv$ address for any host") {

--- a/squbs-unicomplex/src/main/scala/org/squbs/unicomplex/ConfigUtil.scala
+++ b/squbs-unicomplex/src/main/scala/org/squbs/unicomplex/ConfigUtil.scala
@@ -20,13 +20,43 @@ import java.net.{Inet4Address, NetworkInterface}
 import com.typesafe.config.{Config, ConfigException, ConfigMemorySize}
 
 import scala.collection.JavaConversions._
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.matching.Regex
+import scala.reflect.runtime.universe._
 
 object ConfigUtil {
 
+  private val StringTag = typeTag[String]
+  private val StringListTag = typeTag[Seq[String]]
+  private val ConfigTag = typeTag[Config]
+  private val ConfigListTag = typeTag[Seq[Config]]
+  private val RegexTag = typeTag[Regex]
+  private val ConfigMemorySizeTag = typeTag[ConfigMemorySize]
+  private val DurationTag = typeTag[FiniteDuration]
+
   implicit class RichConfig(val underlying: Config) extends AnyVal {
+
+    def getOption[T](path: String)(implicit tag: TypeTag[T]): Option[T] =
+      if (underlying.hasPath(path))
+        (tag match {
+          case StringTag => Some(underlying.getString(path))
+          case StringListTag => Some(underlying.getStringList(path).toSeq)
+          case TypeTag.Int => Some(underlying.getInt(path))
+          case TypeTag.Boolean => Some(underlying.getBoolean(path))
+          case TypeTag.Double => Some(underlying.getDouble(path))
+          case ConfigTag => Some(underlying.getConfig(path))
+          case ConfigListTag => Some(underlying.getConfigList(path).toSeq)
+          case RegexTag => Try(new Regex(underlying.getString(path))).toOption
+          case ConfigMemorySizeTag => Some(underlying.getMemorySize(path))
+          case DurationTag => Some(Duration.create(underlying.getDuration(path, MILLISECONDS), MILLISECONDS))
+          case _ => throw new IllegalArgumentException(s"Configuration option type $tag not implemented")
+        }).asInstanceOf[Option[T]]
+      else None
+
+    def get[T: TypeTag](path: String, default: => T) = getOption[T](path).getOrElse(default)
+
+    def get[T: TypeTag](path: String) = getOption[T](path).getOrElse(throw new ConfigException.Missing(path))
 
     def getOptionalString(path: String): Option[String] = {
       try {

--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/ConfigUtilSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/ConfigUtilSpec.scala
@@ -16,10 +16,11 @@
 
 package org.squbs.unicomplex
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigMemorySize}
 import org.scalatest.{FunSpecLike, Matchers}
 
 import scala.concurrent.duration._
+import scala.util.matching.Regex
 
 class ConfigUtilSpec extends FunSpecLike with Matchers {
 
@@ -46,6 +47,8 @@ class ConfigUtilSpec extends FunSpecLike with Matchers {
       |  ]
       |  timeout = 20s
       |  mem-size = 4m
+      |  correct-regex = "[0-9]"
+      |  incorrect-regex = "("
       |}
     """.stripMargin
 
@@ -59,69 +62,183 @@ class ConfigUtilSpec extends FunSpecLike with Matchers {
       config.getOptionalString("testConfig.str") should be (Some("foo"))
     }
 
-    it ("should get none for non-existing string config") {
+    it ("should read some existing string config by \"getOption\"") {
+      config.getOption[String]("testConfig.str") should be (Some("foo"))
+    }
+    
+    it ("should get None for non-existing string config") {
       config.getOptionalString("str") should be (None)
+    }
+
+    it ("should get None for non-existing string config by \"getOption\"") {
+      config.getOption[String]("str") should be (None)
     }
 
     it ("should read some existing string list config") {
       config.getOptionalStringList("testConfig.str-list") should be (Some(Seq("foo", "bar")))
     }
 
-    it ("should get none for non-existing string list config") {
+    it ("should read some existing string list config by \"getOption\"") {
+      config.getOption[Seq[String]]("testConfig.str-list") should be (Some(Seq("foo", "bar")))
+    }
+    
+    it ("should get None for non-existing string list config") {
       config.getOptionalStringList("str-list") should be (None)
+    }
+
+    it ("should get None for non-existing string list config by \"getOption\"") {
+      config.getOption[Seq[String]]("str-list") should be (None)
     }
 
     it ("should read some existing int config") {
       config.getOptionalInt("testConfig.int-num") should be (Some(10))
     }
 
-    it ("should get none for non-existing int config") {
+    it ("should read some existing int config by \"getOption\"") {
+      config.getOption[Int]("testConfig.int-num") should be (Some(10))
+    }
+    
+    it ("should get None for non-existing int config") {
       config.getOptionalInt("int-num") should be (None)
     }
-
+    
+    it ("should get None for non-existing int config by \"getOption\"") {
+      config.getOption[Int]("int-num") should be (None)
+    }
+    
     it ("should read some existing boolean config") {
       config.getOptionalBoolean("testConfig.bool-val") should be (Some(true))
     }
 
-    it ("should get none for non-existing boolean config") {
+    it ("should read some existing boolean config by \"getOption\"") {
+      config.getOption[Boolean]("testConfig.bool-val") should be (Some(true))
+    }
+
+    it ("should get None for non-existing boolean config") {
       config.getOptionalBoolean("bool-val") should be (None)
+    }
+
+    it ("should get None for non-existing boolean config by \"getOption\"") {
+      config.getOption[Boolean]("bool-val") should be (None)
     }
 
     it ("should read some existing config") {
       config.getOptionalConfig("testConfig.conf") flatMap { _.getOptionalInt("num2")} should be (Some(20))
     }
 
-    it ("should get none for non-existing config") {
+    it ("should read some existing config by \"getOption\"") {
+      config.getOption[Config]("testConfig.conf") flatMap { _.getOptionalInt("num2")} should be (Some(20))
+    }
+
+    it ("should get None for non-existing config") {
       config.getOptionalConfig("conf") should be (None)
+    }
+
+    it ("should get None for non-existing config by \"getOption\"") {
+      config.getOption[Config]("conf") should be (None)
     }
 
     it ("should read some existing config list") {
       config.getOptionalConfigList("testConfig.conf-list").get should have size 2
     }
 
-    it ("should get none for non-existing config list") {
+    it ("should read some existing config list by \"getOption\"") {
+      config.getOption[Seq[Config]]("testConfig.conf-list").get should have size 2
+    }
+
+    it ("should get None for non-existing config list") {
       config.getOptionalConfigList("conf-list") should be (None)
+    }
+
+    it ("should get None for non-existing config list \"getOption\"") {
+      config.getOption[Seq[Config]]("conf-list") should be (None)
     }
 
 		it ("should get duration for existing time") {
 			config.getOptionalDuration("testConfig.timeout").get shouldEqual Duration.create(20, SECONDS)
 		}
 
-		it ("should get none for non-existing duration") {
+    it ("should get duration for existing time by \"getOption\"") {
+      config.getOption[FiniteDuration]("testConfig.timeout").get shouldEqual Duration.create(20, SECONDS)
+    }
+
+		it ("should get None for non-existing duration") {
 			config.getOptionalDuration("non-timeout") shouldBe None
 		}
 
-    it ("should get provide at least one IPv$ address for any host") {
-      ipv4 should fullyMatch regex """\d+\.\d+\.\d+\.\d+"""
-      println(ipv4)
+    it ("should get None for non-existing duration by \"getOption\"") {
+      config.getOption[FiniteDuration]("non-timeout") shouldBe None
     }
 
+    it ("should get a proper Regex for existing value") {
+      config.getOptionalPattern("testConfig.correct-regex").get.pattern.pattern() should be ("""[0-9]""")
+    }
+
+    it ("should get a proper Regex for existing value by \"getOption\"") {
+      config.getOption[Regex]("testConfig.correct-regex").get.pattern.pattern() should be ("""[0-9]""")
+    }
+
+    it ("should get None for non-existing regex value") {
+      config.getOptionalPattern("correct-regex") shouldBe None
+    }
+
+    it ("should get None for non-existing regex value by \"getOption\"") {
+      config.getOption[Regex]("correct-regex") shouldBe None
+    }
+
+    it ("should get None for existing incorrect Regex value") {
+      config.getOptionalPattern("testConfig.incorrect-regex") shouldBe None
+    }
+
+    it ("should get None for existing incorrect Regex value by \"getOption\"") {
+      config.getOption[Regex]("testConfig.incorrect-regex") shouldBe None
+    }
+    
     it ("should get a proper memory size") {
       config.getOptionalMemorySize("testConfig.mem-size") map (_.toBytes) shouldBe Some(4L * 1024 * 1024)
     }
 
-    it ("should get none for non-existing memory size") {
+    it ("should get a proper memory size by \"getOption\"") {
+      config.getOption[ConfigMemorySize]("testConfig.mem-size") map (_.toBytes) shouldBe Some(4L * 1024 * 1024)
+    }
+    
+    it ("should get None for non-existing memory size") {
       config.getOptionalMemorySize("mem-size") shouldBe None
+    }
+
+    it ("should get None for non-existing memory size by \"getOption\"") {
+      config.getOption[ConfigMemorySize]("mem-size") shouldBe None
+    }
+    
+    it ("should get default value for non-existing config string") {
+      config.get("str", "default string") shouldBe "default string"
+    }
+
+    it ("should get config value for existing config string") {
+      config.get[String]("testConfig.str", "default string") shouldBe "foo"
+    }
+
+    it ("should throw ConfigMissing exception for non existing config string") {
+      intercept[ConfigException.Missing](
+        config.get[String]("str")
+      )
+    }
+
+    it ("should throw IllegalArgumentException for unexpected type of existing config value") {
+      intercept[IllegalArgumentException](
+        config.get[Unit]("testConfig.str")
+      )
+    }
+
+    it ("should throw WrongType exception for incorrect type of existing config value") {
+      intercept[ConfigException.WrongType](
+        config.get[Int]("testConfig.str")
+      )
+    }
+
+    it ("should get provide at least one IPv$ address for any host") {
+      ipv4 should fullyMatch regex """\d+\.\d+\.\d+\.\d+"""
+      println(ipv4)
     }
   }
 }

--- a/squbs-zkcluster/.gitignore
+++ b/squbs-zkcluster/.gitignore
@@ -1,0 +1,1 @@
+zookeeper/


### PR DESCRIPTION
util/ConfigUtil and unicomplex/ConfigUtil enhancements
- added method `def getOption[T](path)` to `RichConfig` class
- added method `def get[T](path,  default)` to `RichConfig` class
- added method `def get[T](path)` to `RichConfig` class
- added tests for `Regex` config value