### PR TITLE
#269: Update the package name for SimpleProcessorFactory

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -132,7 +132,7 @@ myProxy {
 
   type = squbs.proxy
 
-  processorFactory = org.squbs.proxy.SimpleProcessorFactory
+  processorFactory = org.squbs.pipeline.SimpleProcessorFactory
 
   settings = {
     inbound = [handler1, handler2]


### PR DESCRIPTION
the right page should be org.squbs.pipeline instead of org.squbs.proxy