### PR TITLE
#282 Update `streaming.LocalPortListenerSpec` to use `headerValueByType`

### DIFF
--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/streaming/LocalPortListenerSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/streaming/LocalPortListenerSpec.scala
@@ -113,10 +113,7 @@ class LocalPortListenerSpec extends TestKit(LocalPortListenerSpecActorSystem.boo
 class LocalPortListenerService extends RouteDefinition {
 
   override def route: Route = get {
-    // TODO https://github.com/akka/akka/issues/20052 seems to be still a problem.  Will tackle in 0.8.1.  We should also
-    // follow the Akka Http convention for header names..
-    // headerValueByType[LocalPortHeader]()(header => complete(header.value))
-    headerValueByName("org.squbs.unicomplex.streaming.LocalPortHeader")(header => complete(header))
+    headerValueByType[LocalPortHeader]()(header => complete(header.value))
   } ~ get {
     complete(0.toString)
   }


### PR DESCRIPTION
Thanks for your pull request.  Please review the following guidelines.

- [ ] Title includes issue id.
- [ ] Description of the change added.
- [ ] Commits are squashed.
- [ ] Tests added.
- [ ] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).

