### PR TITLE
#327 Timeout Flow and Deduplicate

### DIFF
--- a/docs/deduplicate.md
+++ b/docs/deduplicate.md
@@ -1,0 +1,53 @@
+# Deduplicate Stage
+
+### Overview
+
+`Deduplicate` is an Akka Streams `GraphStage` to drop identical (consecutive or non-consecutive) elements  in a stream.
+
+### Dependency
+
+Add the following dependency to your `build.sbt` or scala build file:
+
+```
+"org.squbs" %% "squbs-ext" % squbsVersion
+```
+
+### Usage
+
+The usage is very similar to standard Akka Stream stages:
+
+```scala
+val result = Source("a" :: "b" :: "b" :: "c" :: "a" :: "a" :: "a" :: "c" :: Nil).
+  via(Deduplicate()).
+  runWith(Sink.seq)
+  
+// Output: ("a" :: "b" :: "c" :: Nil)
+```
+
+`Deduplicate` keeps a registry of already seen elements.  To prevent the registry growing unboundedly, it allows to specify the number of duplicates for each message.  Once `duplicateCount` is reached that element is removed from the registry.  In the following example, `duplicateCount` is specified as `2`, so, `"a"` will not be dropped when seen the third time: 
+
+```scala
+val result = Source("a" :: "b" :: "b" :: "c" :: "a" :: "a" :: "a" :: "c" :: Nil).
+  via(Deduplicate(2)).
+  runWith(Sink.seq)
+  
+// Output: ("a" :: "b" :: "c" :: "a" :: Nil)
+```
+
+Please note, `duplicateCount` prevents registry from ever growing when the number of duplicates are known.  However, there is still the potential of memory leaks.  For instance, if `duplicateCount` is set to `2`, an element will be kept in the registry until the duplicate is seen; however, there might be scenarios where duplicate never shows up, e.g., a `filter` or `drop` is used.  So, be aware of consequences of `Duplicate` in your use case.
+
+You can also provide a different registry implementation to `Deduplicate` that cleans itself periodically.  But, you should do this only if you are certain that a duplicate would not be seen after a given time frame; otherwise, the duplication logic might be corrupted.
+
+### Configuring registry key and registry implementation
+
+`Deduplicate` uses the element itself as the key to the registry by default.  However, it also accepts a function to map to a key from the element.  For instance, if the elements in the stream are tuples of type `(Int, String)` and you would like to identify duplicates only based on the first field of the tuple, you can pass a function as follows:
+
+```scala
+val deduplicate = Deduplicate((element: (Int, String)) => element._1, 2)
+```  
+
+`Deduplicate` also allows the registry to replaced with a different implementation of type `java.util.Map[Key, MutableLong]`.
+
+```scala
+val deduplicate = Deduplicate(2, new util.TreeMap[String, MutableLong]())
+```

--- a/docs/flow-timeout.md
+++ b/docs/flow-timeout.md
@@ -1,0 +1,74 @@
+# Timeout Flow
+
+### Overview
+
+Some stream use cases may require each message in a flow to be processed within a bounded time or to return a timeout failure.  Timeout Flow feature adds this feature to standard Akka Stream flows.
+
+### Dependency
+
+Add the following dependency to your `build.sbt` or scala build file:
+
+```
+"org.squbs" %% "squbs-ext" % squbsVersion
+```
+
+### Usage
+
+Importing `org.squbs.streams.StreamTimeout._` adds `withTimeout` methods to Akka Stream Flows.  The result is a `Try` of the flow output type:
+
+   * If the message can be processed within the timeout, the output would be a `Success(msg)`.
+   * Oherwise, the output would be a `Failure(FlowTimeoutException())`.  
+
+```scala
+import org.squbs.streams.StreamTimeout._
+
+val flow = Flow[String].map(s => findTheNumberOfEnglishWordsThatStartWith(s))
+Source("a" :: "b" :: "c" :: Nil).
+  via(flow.withTimeout(20 milliseconds)).
+  runWith(Sink.seq)
+```
+
+#### Message ordering
+
+Internally, the timeout flow broadcasts a message to two branches: one is the original flow and the other is a delay stage (for timeout).  Whichever branch processes the message first wins and the slower one needs to be dropped by a deduplication stage. To deduplicate, each message should be uniqely identifiable.  Accordingly, timeout flow generates an id for each message before broadcasting the message and that id is used to deduplicate the messages later in the stream.  
+
+If the original flow cannot guarantee the message ordering (e.g., usage of `mapAsyncUnordered`), to make sure ids are carried along correctly, timeout flow feature requires id to be carried along.  To carry the context, wrap your `Flow` input/output types with `TimerEnvelope[Id, Value]`.  `Id` is the type used to uniquely identify a message, you can set it to `Long` and use the default id generator (or you can also configure your own type and id generator).  Below is an example usage with `TimerEnvelope`.  Since, `mapAsyncUnordered` is used in the stream, `String` is wrapped with `TimerEnvelope[Long, String]`:  
+
+```scala
+import org.squbs.streams.StreamTimeout._
+import akka.pattern.ask
+implicit val askTimeout = Timeout(5.seconds)
+
+val flow = Flow[TimerEnvelope[Long, String]].mapAsyncUnordered(2) { elem =>
+  (ref ? elem).mapTo[TimerEnvelope[Long, String]]
+}
+
+Source("a" :: "b" :: "c" :: Nil).via(flow.withTimeout(20 milliseconds)).runWith(Sink.seq)
+```
+
+#### Configuring `Id` type and `Id` generators
+
+Timeout flow feature defines default `Id` type as `Long` and provides a default `Id` generator.  However, it also allows to configure it.  You can use any type as an `Id` and provide a custom `Id` generator.  `Id` generator is just a function with return type of the `Id`.  Below is an example that uses `BigInt` instead of `Long`:
+
+```scala
+class BigIntIdGenerator {
+  var id = BigInt(0)
+  
+  def nextId() = () => {
+    id = id + 1
+    id
+  }
+}
+
+import org.squbs.streams.StreamTimeout._
+import akka.pattern.ask
+implicit val askTimeout = Timeout(5.seconds)
+
+val flow = Flow[TimerEnvelope[BigInt, String]].mapAsyncUnordered(2) { elem =>
+  (ref ? elem).mapTo[TimerEnvelope[BigInt, String]]
+}
+
+Source("a" :: "b" :: "c" :: Nil).
+  via(flow.withTimeout(20 milliseconds, (new BigIntIdGenerator).nextId())).
+  runWith(Sink.seq)
+```

--- a/squbs-ext/src/main/scala/org/squbs/streams/Deduplicate.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/Deduplicate.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import akka.stream.ActorAttributes.SupervisionStrategy
+import akka.stream.{Supervision, Attributes}
+import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
+import akka.stream.stage.{InHandler, OutHandler, GraphStageLogic}
+
+import scala.util.control.NonFatal
+
+object Deduplicate {
+
+  def apply[T, U](key: T => U, duplicateCount: Long) =
+    new Deduplicate[T, U](key, duplicateCount, new java.util.HashMap[U, MutableLong]())
+
+  def apply[T, U](key: T => U, duplicateCount: Long, registry: java.util.Map[U, MutableLong]) =
+    new Deduplicate[T, U](key, duplicateCount, registry)
+
+  def apply[T](duplicateCount: Long = Long.MaxValue,
+               registry: java.util.Map[T, MutableLong] = new java.util.HashMap[T, MutableLong]()): Deduplicate[T, T] =
+    Deduplicate(t => t, duplicateCount, registry)
+}
+
+/**
+  * Only pass on those elements that have not been seen so far.
+  *
+  * '''Emits when''' the element is not a duplicate
+  *
+  * '''Backpressures when''' the element is not a duplicate and downstream backpressures
+  *
+  * '''Completes when''' upstream completes
+  *
+  * '''Cancels when''' downstream cancels
+  */
+final class Deduplicate[T, U](key: T => U, duplicateCount: Long = Long.MaxValue,
+                              registry: java.util.Map[U, MutableLong] = new java.util.HashMap[U, MutableLong]())
+  extends SimpleLinearGraphStage[T] {
+
+  require(duplicateCount >= 2)
+
+  override def toString: String = "Deduplicate"
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with OutHandler with InHandler {
+      def decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+
+      import scala.compat.java8.FunctionConverters._
+      val incrementOrRemove: (MutableLong, MutableLong) => MutableLong = (old, default) => {
+        pull(in)
+        if(old.increment() == duplicateCount) null else old
+      }
+
+      override def onPush(): Unit = {
+        try {
+          val elem = grab(in)
+          val counter = registry.merge(key(elem), MutableLong(1), incrementOrRemove.asJava)
+          if(counter != null && counter.value == 1) {
+            push(out, elem)
+          }
+        } catch {
+          case NonFatal(ex) ⇒ decider(ex) match {
+            case Supervision.Stop ⇒ failStage(ex)
+            case _                ⇒ pull(in)
+          }
+        }
+      }
+
+      override def onPull(): Unit = pull(in)
+
+      setHandlers(in, out, this)
+    }
+}
+
+/**
+  * [[MutableLong]] is used to avoid boxing/unboxing and also
+  * to avoid [[java.util.Map#put]] operation to increment the counters in the registry.
+  *
+  * @param value
+  */
+case class MutableLong(var value: Long = 0L) {
+  def increment() = {
+    value += 1
+    value
+  }
+}

--- a/squbs-ext/src/main/scala/org/squbs/streams/StreamTimeout.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/StreamTimeout.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import akka.stream.FlowShape
+import akka.stream.scaladsl._
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Try}
+
+object StreamTimeout {
+
+  implicit class TimeoutFlowUnordered[Id, In, Out, Mat](flow: Flow[TimerEnvelope[Id, In], TimerEnvelope[Id, Out], Mat]) {
+
+    /**
+      *                                             +------------+
+      *       +---------------+    +-----------+    |  Original  |    +---------+    +-------------+    +---------------+
+      *       |               |    |           0 ~> 0    Flow    0 ~> 0         |    |             |    |               |
+      *       |  Generate Id  |    |           |    +------------+    |         |    |             |    |   Map from    |
+      * In ~> 0   and map to  0 ~> 0 Broadcast |                      |  Merge  0 ~> 0 Deduplicate 0 ~> 0 TimerEnvelope 0 ~> Try[Out]
+      *       | TimerEnvelope |    |           |    +------------+    |         |    |             |    |   to Value    |
+      *       |               |    |           0 ~> 0  Delay for 0 ~> 0         |    |             |    |               |
+      *       +---------------+    +-----------+    |  timeout   |    +---------+    +-------------+    +---------------+
+      *                                             +------------+
+      *
+      */
+    def withTimeout(timeout: FiniteDuration, idGenerator: () => Id): Flow[In, Try[Out], Mat] = {
+
+      Flow.fromGraph(GraphDSL.create(flow) { implicit b =>
+        originalFlow =>
+          import GraphDSL.Implicits._
+
+          val converter = new TimerEnvelopeConverter(idGenerator)
+          val toTimerEnvelope = b.add(Flow[In].map[TimerEnvelope[Id, In]](e => converter.toTimerEnvelope(e)))
+          val merge = b.add(Merge[TimerEnvelope[Id, Try[Out]]](2))
+          val broadcast = b.add(Broadcast[TimerEnvelope[Id, In]](2).async)
+
+          val deDuplicate = b.add(Deduplicate[TimerEnvelope[Id, Try[Out]], Id]
+            ((t: TimerEnvelope[Id, Try[Out]]) => t.id,
+            2,
+            new java.util.HashMap[Id, MutableLong]()))
+          val fromTimerEnvelope = b.add(Flow[TimerEnvelope[Id, Try[Out]]].map(e => e.value))
+
+          val mapToSuccess = Flow[TimerEnvelope[Id, Out]].map { case TimerEnvelope(id, element) =>
+            TimerEnvelope[Id, Try[Out]](id, Try(element))
+          }
+
+          val mapToFailure = Flow[TimerEnvelope[Id, In]].map { case TimerEnvelope(id, _) =>
+            TimerEnvelope[Id, Try[Out]](id, Failure(FlowTimeoutException()))
+          }
+
+          toTimerEnvelope ~> broadcast ~> originalFlow ~> mapToSuccess ~> merge ~> deDuplicate ~> fromTimerEnvelope
+                             broadcast.delay(timeout)  ~> mapToFailure ~> merge
+
+          FlowShape(toTimerEnvelope.in, fromTimerEnvelope.out)
+      })
+    }
+  }
+
+  implicit class TimeoutFlowUnorderedLong[In, Out, Mat]
+  (flow: Flow[TimerEnvelope[Long, In], TimerEnvelope[Long, Out], Mat]) {
+
+    def withTimeout(timeout: FiniteDuration): Flow[In, Try[Out], Mat] = {
+      val flowWithLongId = new TimeoutFlowUnordered[Long, In, Out, Mat](flow)
+      flowWithLongId.withTimeout(timeout, LongIdGenerator().nextId())
+    }
+  }
+
+  implicit class TimeoutFlow[Id, In, Out, Mat](flow: Flow[In, Out, Mat]) {
+
+    def withTimeout(timeout: FiniteDuration): Flow[In, Try[Out], Mat] = {
+      flow.withTimeout(timeout, LongIdGenerator().nextId())
+    }
+
+    def withTimeout(timeout: FiniteDuration,
+                    idGenerator: () => Id): Flow[In, Try[Out], Mat] = {
+
+      /*
+                                 +----------+                                  +----------+
+                                 |          |                                  |          |
+                                 |          0 ~> Id ~~~~~~~~~~~~~~~~~~~~~~~~~> 0          |
+        TimerEnvelope[Id, In] ~> 0  Unzip   |          +-----------+           |   Zip    0 ~> TimerEnvelope[Id, Out]
+                                 |          |          |           |           |          |
+                                 |          0 ~> In ~> 0  Original 0 ~> Out ~> 0          |
+                                 +----------+          |   Flow    |           +----------+
+                                                       |           |
+                                                       +-----------+
+
+       */
+      def timerEnvelopeAdapter[In, Out, Mat](flow: Flow[In, Out, Mat]):
+      Flow[TimerEnvelope[Id, In], TimerEnvelope[Id, Out], Mat] = {
+        Flow.fromGraph(GraphDSL.create(flow) { implicit b =>
+          originalFlow =>
+            import GraphDSL.Implicits._
+
+            val unzip = b.add(UnzipWith[TimerEnvelope[Id, In], Id, In] { envelope => (envelope.id, envelope.value) })
+            val zip = b.add(ZipWith[Id, Out, TimerEnvelope[Id, Out]] {
+              case (id, value) => TimerEnvelope[Id, Out](id, value)
+            })
+
+            unzip.out0                 ~> zip.in0
+            unzip.out1 ~> originalFlow ~> zip.in1
+
+            FlowShape(unzip.in, zip.out)
+        })
+      }
+
+      timerEnvelopeAdapter(flow).withTimeout(timeout, idGenerator)
+    }
+  }
+
+  case class TimerEnvelope[Id, Value](val id: Id, val value: Value)
+
+  class TimerEnvelopeConverter[Id](idGenerator: () => Id) {
+
+    def toTimerEnvelope[Value](element: Value) = {
+      TimerEnvelope[Id, Value](idGenerator(), element)
+    }
+  }
+
+  case class FlowTimeoutException(msg: String = "Flow timed out!") extends Exception(msg)
+
+  object LongIdGenerator {
+    def apply() = new LongIdGenerator()
+  }
+
+  class LongIdGenerator {
+    // This is not concurrent, nor needs it to be
+    var id = 0L
+
+    def nextId() = { () =>
+      // It may overflow, which should be ok for most scenarios.  If the message with id 0 is still not completed
+      // after it overflowed, then deduplication logic would be broken.  For such scenarios, a different
+      // id generator should be used.
+      id = id + 1
+      id
+    }
+  }
+}

--- a/squbs-ext/src/test/scala/org/squbs/streams/DeduplicateSpec.scala
+++ b/squbs-ext/src/test/scala/org/squbs/streams/DeduplicateSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import java.util
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl._
+import akka.stream.ActorMaterializer
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+class DeduplicateSpec extends AsyncFlatSpec with Matchers{
+
+  implicit val system = ActorSystem("DeduplicateSpec")
+  implicit val materializer = ActorMaterializer()
+
+  it should "require duplicateCount >= 2" in {
+    an [IllegalArgumentException] should be thrownBy
+      Source("a" :: "a" :: "b" :: "b" :: "c" :: "c" :: Nil).via(Deduplicate(1)).runWith(Sink.seq)
+
+  }
+
+  it should "filter consecutive duplicates" in {
+    val result = Source("a" :: "a" :: "b" :: "b" :: "c" :: "c" :: Nil).via(Deduplicate(2)).runWith(Sink.seq)
+    result map { s => s should contain theSameElementsInOrderAs ("a" :: "b" :: "c" :: Nil)}
+  }
+
+  it should "filter unordered duplicates" in {
+    val result = Source("a" :: "b" :: "b" :: "c" :: "a" :: "c" :: Nil).via(Deduplicate(2)).runWith(Sink.seq)
+    result map { s => s should contain theSameElementsInOrderAs ("a" :: "b" :: "c" :: Nil)}
+  }
+
+  it should "filter when identical element count is greater than 2" in {
+    val result = Source("a" :: "a" :: "b" :: "b" :: "b" :: "c" :: "a" :: "c" :: "c" :: Nil).
+      via(Deduplicate(3)).runWith(Sink.seq)
+    result map { s => s should contain theSameElementsInOrderAs ("a" :: "b" :: "c" :: Nil)}
+  }
+
+  it should "filter all identical elements when duplicate count is not specified" in {
+    val result = Source("a" :: "b" :: "b" :: "c" :: "a" :: "a" :: "a" :: "c" :: Nil).via(Deduplicate()).runWith(Sink.seq)
+    result map { s => s should contain theSameElementsInOrderAs ("a" :: "b" :: "c" :: Nil)}
+  }
+
+  it should "allow identical elements after duplicate count is reached" in {
+    val result = Source("a" :: "a" :: "b" :: "b" :: "b" :: "c" :: "a" :: "c" :: "c" :: Nil).
+      via(Deduplicate(2)).runWith(Sink.seq)
+    result map { s => s should contain theSameElementsInOrderAs ("a" :: "b" :: "b" :: "c" :: "a" :: "c" :: Nil)}
+  }
+
+  it should "remove an element from registry when duplicate count is reached" in {
+    val map = new util.HashMap[String, MutableLong]()
+    val result = Source("a" :: "a" :: "b" :: "c" :: "c" :: Nil).via(Deduplicate(2, map)).runWith(Sink.seq)
+    result map { s =>
+      s should contain theSameElementsInOrderAs ("a" :: "b" :: "c" :: Nil)
+      map should have size 1
+      map.get("b") shouldEqual MutableLong(1)
+    }
+  }
+
+  it should "work with a custom registry" in {
+    val treeMap = new util.TreeMap[String, MutableLong]()
+    val result = Source("a" :: "a" :: "b" :: "b" :: "c" :: "c" :: Nil).via(Deduplicate(2, treeMap)).runWith(Sink.seq)
+    result map { s =>
+      s should contain theSameElementsInOrderAs ("a" :: "b" :: "c" :: Nil)
+      treeMap shouldBe empty
+    }
+  }
+
+  it should "work with a custom key function" in {
+    val result = Source((1 -> "a") :: (1 -> "sameKey") ::
+                        (2 -> "b") :: (2 -> "b") ::
+                        (3 -> "c") :: (3 -> "c") :: Nil).
+                via(Deduplicate((element: (Int, String)) => element._1, 2)).runWith(Sink.seq)
+    result map { s =>
+      s should contain theSameElementsInOrderAs ((1 -> "a") :: (2 -> "b") :: (3 -> "c") :: Nil)
+    }
+  }
+}

--- a/squbs-ext/src/test/scala/org/squbs/streams/TimeoutFlowSpec.scala
+++ b/squbs-ext/src/test/scala/org/squbs/streams/TimeoutFlowSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import akka.actor.{Actor, ActorSystem, Props}
+import akka.stream.{ActorMaterializer, FlowShape}
+import akka.stream.scaladsl._
+import akka.testkit.TestKit
+import akka.util.Timeout
+import org.scalatest.{AsyncFlatSpecLike, Matchers}
+import org.squbs.streams.StreamTimeout.TimerEnvelope
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class TimeoutFlowSpec extends TestKit(ActorSystem("TimeoutFlowSpec")) with AsyncFlatSpecLike with Matchers{
+
+  implicit val materializer = ActorMaterializer()
+  import StreamTimeout._
+
+  val timeout = 30 milliseconds
+
+  it should "timeout a message if the flow does not process it within provided timeout" in {
+    import scala.concurrent.duration._
+
+    val flow = Flow.fromGraph(GraphDSL.create() { implicit b =>
+      import GraphDSL.Implicits._
+
+      val partition = b.add(Partition(3, (s: String) => s match {
+        case "a" => 0
+        case "b" => 1
+        case "c" => 2
+      }))
+
+      val merge = b.add(Merge[String](3))
+
+      partition.out(0).delay(10 milliseconds)  ~> merge
+      partition.out(1).delay(100 milliseconds) ~> merge
+      partition.out(2).delay(10 milliseconds)  ~> merge
+
+      FlowShape(partition.in, merge.out)
+    })
+
+    val result = Source("a" :: "b" :: "c" :: Nil).via(flow.withTimeout(timeout)).runWith(Sink.seq)
+    // "c" fails because of slowness of "b"
+    val expected = Success("a") :: Failure(FlowTimeoutException()) :: Failure(FlowTimeoutException()) :: Nil
+    result map { _ should contain theSameElementsAs expected }
+  }
+
+  it should "work for flows that keep the order of messages" in {
+    val delayActor = system.actorOf(Props[DelayActor])
+    import akka.pattern.ask
+    implicit val askTimeout = Timeout(5.seconds)
+    val flow = Flow[String].mapAsync(3)(elem => (delayActor ? elem).mapTo[String])
+
+    val result = Source("a" :: "b" :: "c" :: Nil).via(flow.withTimeout(timeout)).runWith(Sink.seq)
+    // "c" fails because of slowness of "b"
+    val expected = Success("a") :: Failure(FlowTimeoutException()) :: Failure(FlowTimeoutException()) :: Nil
+    result map { _ should contain theSameElementsInOrderAs expected }
+  }
+
+  it should "work for flows that do not keep the order of messages" in {
+    val delayActor = system.actorOf(Props[DelayActor])
+    import akka.pattern.ask
+    implicit val askTimeout = Timeout(5.seconds)
+    val flow = Flow[TimerEnvelope[Long, String]].mapAsyncUnordered(3) { elem =>
+      (delayActor ? elem).mapTo[TimerEnvelope[Long, String]]
+    }
+
+    val result = Source("a" :: "b" :: "c" :: Nil).via(flow.withTimeout(timeout)).runWith(Sink.seq)
+    // "c" does NOT fail because the original flow lets it go earlier than "b"
+    val expected = Success("a") :: Failure(FlowTimeoutException()) :: Success("c") :: Nil
+    result map { _ should contain theSameElementsAs expected }
+  }
+
+  it should "allow a custom id generator to be passed in" in {
+    val delayActor = system.actorOf(Props[DelayActor])
+    import akka.pattern.ask
+    implicit val askTimeout = Timeout(5.seconds)
+    val flow = Flow[String].mapAsync(3)(elem => (delayActor ? elem).mapTo[String])
+
+    val result = Source("a" :: "b" :: "c" :: Nil).via(flow.withTimeout(timeout,
+                                                      (new BigIntIdGenerator).nextId())).runWith(Sink.seq)
+    // "c" fails because of slowness of "b"
+    val expected = Success("a") :: Failure(FlowTimeoutException()) :: Failure(FlowTimeoutException()) :: Nil
+    result map { _ should contain theSameElementsInOrderAs expected }
+  }
+
+  it should "allow a custom id generator to be passed in for flows that do not keep the order of messages" in {
+    val delayActor = system.actorOf(Props[DelayActor])
+    import akka.pattern.ask
+    implicit val askTimeout = Timeout(5.seconds)
+    val flow = Flow[TimerEnvelope[BigInt, String]].mapAsyncUnordered(3) { elem =>
+      (delayActor ? elem).mapTo[TimerEnvelope[BigInt, String]]
+    }
+
+    val result = Source("a" :: "b" :: "c" :: Nil).via(flow.withTimeout(timeout,
+                                                      (new BigIntIdGenerator).nextId())).runWith(Sink.seq)
+    // "c" does NOT fail because the original flow lets it go earlier than "b"
+    val expected = Success("a") :: Failure(FlowTimeoutException()) :: Success("c") :: Nil
+    result map { _ should contain theSameElementsAs expected }
+  }
+}
+
+class BigIntIdGenerator {
+  // This is not concurrent, nor needs it to be
+  var id = BigInt(0)
+
+  def nextId() = () => {
+    // It may overflow, which should be ok for most scenarios.  If the message with id 0 is still not completed
+    // after it overflowed, then deduplication logic would be broken.  For such scenarios, a different
+    // id generator should be used.
+    id = id + 1
+    id
+  }
+}
+
+class DelayActor extends Actor {
+
+  val delay = Map("a" -> 10.milliseconds, "b" -> 100.milliseconds, "c" -> 10.milliseconds)
+
+  def receive = {
+    case element: String =>
+      import context.dispatcher
+      context.system.scheduler.scheduleOnce(delay(element), sender(), element)
+    case element: TimerEnvelope[Long, String] =>
+      import context.dispatcher
+      context.system.scheduler.scheduleOnce(delay(element.value), sender(), element)
+  }
+}


### PR DESCRIPTION
Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [x] Documentation added/updated.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).


We should try to optimize the flow by eliminating the `async` boundary (or limit it to the `delay` branch).  We should tackle it with https://github.com/paypal/squbs/issues/354.

We should also look at `onUpstreamFinish` and `onUpstreamFailure` scenarios in more detail with https://github.com/paypal/squbs/issues/355.

Also, created a story to add a JMX bean for the `Deduplicate` registry size: https://github.com/paypal/squbs/issues/356.

Per suggestion of @akara, we should also explore a `BidiFlow` based API: https://github.com/paypal/squbs/issues/359.