### PR TITLE
#369: Made CustomTestKit scan resources in src/main/resources, too.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,7 @@ The `CustomTestKit` is used for starting a full blown squbs instance needed for 
    * It automatically sets actor system name to spec/test class name for simplicity and also to ensure `ActorSystem` instances do not conflict.  But, it also allows actor system name to be passed in the constructor.
    * Tests extending `CustomTestKit` can run in parallel in the same JVM.
    * Starts and stops squbs automatically.
-   * Starts well-known actors and service in `src/test/resources/META-INF/squbs-meta.conf` by default.  But, allows passing `resources` to be scanned in the constructor.
+   * Starts well-known actors and service in `src/main/resources/META-INF/squbs-meta.conf` and `src/test/resources/META-INF/squbs-meta.conf` by default.  But, allows passing `resources` to be scanned in the constructor.
    * Allows custom configuration to be passed in the constructor.
 
 Here is an example usage of `CustomTestKit` in ScalaTest:

--- a/squbs-testkit/src/main/scala/org/squbs/testkit/japi/CustomTestKit.scala
+++ b/squbs-testkit/src/main/scala/org/squbs/testkit/japi/CustomTestKit.scala
@@ -44,6 +44,10 @@ abstract class AbstractCustomTestKit(val boot: UnicomplexBoot) extends PortGette
     this(SCustomTestKit.boot(config = Option(config)))
   }
 
+  def this(withClassPath: Boolean) {
+    this(SCustomTestKit.boot(withClassPath = Option(withClassPath)))
+  }
+
   def this(resources: java.util.List[String], withClassPath: Boolean) {
     this(SCustomTestKit.boot(resources = Option(resources.toList), withClassPath = Option(withClassPath)))
   }

--- a/squbs-testkit/src/test/java/org/squbs/testkit/japi/AbstractCustomTestKitNoClassPathTest.java
+++ b/squbs-testkit/src/test/java/org/squbs/testkit/japi/AbstractCustomTestKitNoClassPathTest.java
@@ -1,0 +1,28 @@
+package org.squbs.testkit.japi;
+
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class AbstractCustomTestKitNoClassPathTest extends AbstractCustomTestKit {
+
+    public AbstractCustomTestKitNoClassPathTest() {
+        super(false);
+    }
+
+    @Test
+    public void testDefaultListenerStarted() {
+        assertEquals(port("default-listener"), port());
+    }
+
+    @Test
+    public void testActorSystemName() {
+        assertTrue(system().name().matches("org-squbs-testkit-japi-AbstractCustomTestKitNoClassPathTest-\\d+"));
+    }
+
+    @Test
+    public void testDefaultResources() {
+        assertEquals(1, boot().cubes().size());
+        assertEquals("CustomTestKitDefaultSpec", boot().cubes().head().info().name());
+    }
+}

--- a/squbs-testkit/src/test/scala/org/squbs/testkit/CustomTestKitSpec.scala
+++ b/squbs-testkit/src/test/scala/org/squbs/testkit/CustomTestKitSpec.scala
@@ -174,6 +174,15 @@ with FlatSpecLike with Matchers {
   }
 }
 
+class CustomTestKitWithResourceDetectSpec extends CustomTestKit(false)
+  with FlatSpecLike with Matchers {
+
+  it should "start default-listener" in {
+    noException should be thrownBy port
+    port shouldEqual port("default-listener")
+  }
+}
+
 object CustomTestKitConfigAndResourcesSpec {
 
   val resources = Seq(getClass.getClassLoader.getResource("").getPath + "/CustomTestKitTest/META-INF/squbs-meta.conf")

--- a/squbs-unicomplex/src/main/scala/org/squbs/unicomplex/UnicomplexBoot.scala
+++ b/squbs-unicomplex/src/main/scala/org/squbs/unicomplex/UnicomplexBoot.scala
@@ -35,6 +35,7 @@ import org.squbs.unicomplex.UnicomplexBoot.CubeInit
 
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
@@ -114,7 +115,9 @@ object UnicomplexBoot extends LazyLogging {
         Seq("conf", "json", "properties") flatMap { ext => loader.getResources(s"META-INF/squbs-meta.$ext") }
       } else Seq.empty
 
-    val jarConfigs = (cpResources ++ resources) map readConfigs collect { case Some(jarCfg) => jarCfg }
+    // Dedup the resources, just in case.
+    val allResources = mutable.LinkedHashSet(cpResources ++ resources : _*).toSeq
+    val jarConfigs = allResources map readConfigs collect { case Some(jarCfg) => jarCfg }
     resolveCubes(jarConfigs, boot)
   }
 


### PR DESCRIPTION
We now need to avoid resource duplication. So built dedup logic into UnicomplexBoot resource scanning.


Thanks for your pull request.  Please review the following guidelines.

- [X] Title includes issue id.
- [X] Description of the change added.
- [X] Commits are squashed.
- [X] Tests added.
- [X] Documentation added/updated.
- [X] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
