### PR TITLE
Update: #381 Rev akka/akka-http versions to latest

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -15,8 +15,8 @@
  */
 
 object Versions {
-  val akkaV = "2.4.14"
-  val akkaHttpV = "10.0.0"
+  val akkaV = "2.4.16"
+  val akkaHttpV = "10.0.3"
   val scalatestV = "3.0.0"
   val jacksonV = "2.8.5"
   val json4sV = "3.5.0"

--- a/squbs-httpclient/build.sbt
+++ b/squbs-httpclient/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" 			      	% "3.1.0",
   "org.scala-lang.modules"    %% "scala-java8-compat"           % "0.7.0",
   "org.scalatest"             %% "scalatest"                    % scalatestV % "test->*",
-  "com.typesafe.akka"         %% "akka-testkit"                 % akkaV % "test",
+  "com.typesafe.akka"         %% "akka-testkit"                 % akkaV,
   "com.novocode" % "junit-interface" % junitInterfaceV % "test->default",
   "ch.qos.logback" % "logback-classic" % "1.1.3" % "test"
 )

--- a/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowHttpsEndpointTest.java
+++ b/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowHttpsEndpointTest.java
@@ -62,7 +62,7 @@ public class ClientFlowHttpsEndpointTest {
     static {
         ServerBinding binding;
         try {
-            final ConnectWithHttps ic = ConnectHttp.toHostHttps("localhost", 65529);
+            final ConnectWithHttps ic = ConnectHttp.toHostHttps("localhost", 0);
             final ConnectWithHttps c = sslContext("example.com.jks", "1234567890")
                     .map(sc -> ic.withCustomHttpsContext(ConnectionContext.https(sc)))
                     .orElse(ic.withDefaultHttpsContext());

--- a/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowHttpsEnvTest.java
+++ b/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowHttpsEnvTest.java
@@ -59,7 +59,7 @@ public class ClientFlowHttpsEnvTest {
     static {
         ServerBinding binding;
         try {
-            final ConnectWithHttps ic = ConnectHttp.toHostHttps("localhost", 65528);
+            final ConnectWithHttps ic = ConnectHttp.toHostHttps("localhost", 0);
             final ConnectWithHttps c = sslContext("example.com.jks", "1234567890")
                     .map(sc -> ic.withCustomHttpsContext(ConnectionContext.https(sc)))
                     .orElse(ic.withDefaultHttpsContext());

--- a/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowHttpsTest.java
+++ b/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowHttpsTest.java
@@ -58,7 +58,7 @@ public class ClientFlowHttpsTest {
     static {
         ServerBinding binding;
         try {
-            final ConnectWithHttps ic = ConnectHttp.toHostHttps("localhost", 65527);
+            final ConnectWithHttps ic = ConnectHttp.toHostHttps("localhost", 0);
             final ConnectWithHttps c = sslContext("example.com.jks", "1234567890")
                     .map(sc -> ic.withCustomHttpsContext(ConnectionContext.https(sc)))
                     .orElse(ic.withDefaultHttpsContext());

--- a/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowPipelineTest.java
+++ b/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowPipelineTest.java
@@ -95,7 +95,7 @@ public class ClientFlowPipelineTest {
         ServerBinding binding;
         try {
             binding = Http.get(system).
-                    bindAndHandle(flow, ConnectHttp.toHost("localhost", 65526), mat).
+                    bindAndHandle(flow, ConnectHttp.toHost("localhost", 0), mat).
                     toCompletableFuture().get();
         } catch(Exception e) {
             binding = null;

--- a/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowTest.java
+++ b/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowTest.java
@@ -52,7 +52,7 @@ public class ClientFlowTest {
         ServerBinding binding;
         try {
             binding = Http.get(system).
-                    bindAndHandle(flow, ConnectHttp.toHost("localhost", 65525), mat).
+                    bindAndHandle(flow, ConnectHttp.toHost("localhost", 0), mat).
                     toCompletableFuture().get();
         } catch(Exception e) {
             binding = null;


### PR DESCRIPTION
- Update akka-http version to latest (10.0.3)
- Update akka version to latest (2.4.16)
- Remove the hard coded port in httpclient tests


Thanks for your pull request.  Please review the following guidelines.

- [X ] Title includes issue id.
- [X] Description of the change added.
- [X] Commits are squashed.
- [X] Tests added.
- [ ] Documentation added/updated.
- [X] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
