### PR TITLE
Update: #379 return CompletionStage in ActorLookup

### DIFF
--- a/squbs-actorregistry/src/main/scala/org/squbs/actorregistry/japi/ActorLookup.scala
+++ b/squbs-actorregistry/src/main/scala/org/squbs/actorregistry/japi/ActorLookup.scala
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2015 PayPal
+ *  Copyright 2015-2017 PayPal
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 package org.squbs.actorregistry.japi
 
 import java.util.Optional
+import java.util.concurrent.CompletionStage
 
 import akka.actor.{ActorRef, ActorRefFactory}
 import akka.util.Timeout
 import org.squbs.actorregistry.{ActorLookup => SActorLookup}
 
+import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -66,17 +68,17 @@ class ActorLookup[T <: AnyRef] private[japi] (private[japi] val name: Option[Str
  *
     * @param msg The message to send
     * @param timeout The response timeout, in milliseconds
-    * @return The Future of the response
+    * @return The CompletionStage of the response
     */
-  def ask(msg: Any, timeout: Long): Future[T] = ask(msg, timeout.milliseconds)
+  def ask(msg: Any, timeout: Long): CompletionStage[T] = ask(msg, timeout.milliseconds)
 
   /**
     * Sends a message to an ActorRef
     * @param msg The message to send
     * @param timeout The response timeout
-    * @return The Future of the response
+    * @return The CompletionStage of the response
     */
-  def ask(msg: Any, timeout: Timeout): Future[T] = getLookup(msg).ask(msg)(timeout, refFactory)
+  def ask(msg: Any, timeout: Timeout): CompletionStage[T] = getLookup(msg).ask(msg)(timeout, refFactory).toJava
 
   def resolveOne(timeout: FiniteDuration): Future[ActorRef] =
     new SActorLookup(responseType, requestType, name, responseType != classOf[AnyRef]).resolveOne(timeout)
@@ -110,6 +112,7 @@ class ActorLookup[T <: AnyRef] private[japi] (private[japi] val name: Option[Str
     */
   def lookup[U <: AnyRef](name: String, responseType: Class[U]): ActorLookup[U] =
     new ActorLookup(Some(name), None, responseType)(refFactory)
+
 
   /**
     * Creates an ActorLookup looking up an actor by name.

--- a/squbs-actorregistry/src/test/java/org/squbs/actorregistry/japi/ActorRegistryTest.java
+++ b/squbs-actorregistry/src/test/java/org/squbs/actorregistry/japi/ActorRegistryTest.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 import static org.junit.Assert.*;
 import static org.squbs.testkit.Timeouts.*;
@@ -87,10 +88,10 @@ public class ActorRegistryTest {
     @Test
     public void testSimpleAsk() {
         new DebugTimingTestKit(testKit.actorSystem()) {{
-            Future<?> future = lookup.ask(new TestRequest("ActorLookup"), askTimeout());
+            CompletionStage<?> stage = lookup.ask(new TestRequest("ActorLookup"), askTimeout());
+
             try {
-                Object result = Await.result(future, awaitMax());
-                assertEquals(new TestResponse("ActorLookup"), result);
+                assertEquals(new TestResponse("ActorLookup"), stage.toCompletableFuture().get());
             } catch (Exception e) {
                 fail("Awaiting for response");
             }
@@ -101,10 +102,10 @@ public class ActorRegistryTest {
     public void testSimpleAskWithMsTimeout() {
         long timeout = askTimeout().duration().toMillis();
         new DebugTimingTestKit(testKit.actorSystem()) {{
-            Future<?> future = lookup.ask(new TestRequest("ActorLookup"), timeout);
+            CompletionStage<?> stage = lookup.ask(new TestRequest("ActorLookup"), timeout);
+
             try {
-                Object result = Await.result(future, awaitMax());
-                assertEquals(new TestResponse("ActorLookup"), result);
+                assertEquals(new TestResponse("ActorLookup"), stage.toCompletableFuture().get());
             } catch (Exception e) {
                 fail("Awaiting for response");
             }
@@ -170,11 +171,10 @@ public class ActorRegistryTest {
     @Test
     public void testAskByType() {
         new DebugTimingTestKit(testKit.actorSystem()) {{
-            Future<TestResponse> future = lookup.lookup(TestResponse.class)
+            CompletionStage<TestResponse> stage = lookup.lookup(TestResponse.class)
                     .ask(new TestRequest("ActorLookup[TestResponse]"), askTimeout());
             try {
-                TestResponse result = Await.result(future, awaitMax());
-                assertEquals(new TestResponse("ActorLookup[TestResponse]"), result);
+                assertEquals(new TestResponse("ActorLookup[TestResponse]"), stage.toCompletableFuture().get());
             } catch (Exception e) {
                 fail("Awaiting for response");
             }
@@ -192,11 +192,10 @@ public class ActorRegistryTest {
     @Test
     public void testAskByName() {
         new DebugTimingTestKit(testKit.actorSystem()) {{
-            Future<?> future = lookup.lookup("TestActor")
+            CompletionStage<?> stage = lookup.lookup("TestActor")
                     .ask(new TestRequest("ActorLookup[TestResponse]"), askTimeout());
             try {
-                Object result = Await.result(future, awaitMax());
-                assertEquals(new TestResponse("ActorLookup[TestResponse]"), result);
+                assertEquals(new TestResponse("ActorLookup[TestResponse]"), stage.toCompletableFuture().get());
             } catch (Exception e) {
                 fail("Awaiting for response");
             }
@@ -214,11 +213,10 @@ public class ActorRegistryTest {
     @Test
     public void testAskOptionalName() {
         new DebugTimingTestKit(testKit.actorSystem()) {{
-            Future<?> future = lookup.lookup(Optional.of("TestActor"))
+            CompletionStage<?> stage = lookup.lookup(Optional.of("TestActor"))
                     .ask(new TestRequest("ActorLookup[TestResponse]"), askTimeout());
             try {
-                Object result = Await.result(future, awaitMax());
-                assertEquals(new TestResponse("ActorLookup[TestResponse]"), result);
+                assertEquals(new TestResponse("ActorLookup[TestResponse]"), stage.toCompletableFuture().get());
             } catch (Exception e) {
                 fail("Awaiting for response");
             }
@@ -238,11 +236,11 @@ public class ActorRegistryTest {
     @Test
     public void testAskByTypeAndName() {
         new DebugTimingTestKit(testKit.actorSystem()) {{
-            Future<TestResponse> future = lookup.lookup("TestActor", TestResponse.class)
+            CompletionStage<TestResponse> stage = lookup.lookup("TestActor", TestResponse.class)
                     .ask(new TestRequest("ActorLookup[TestResponse]('TestActor')"), askTimeout());
             try {
-                TestResponse result = Await.result(future, awaitMax());
-                assertEquals(new TestResponse("ActorLookup[TestResponse]('TestActor')"), result);
+                assertEquals(new TestResponse("ActorLookup[TestResponse]('TestActor')"),
+                        stage.toCompletableFuture().get());
             } catch (Exception e) {
                 fail("Awaiting for response");
             }
@@ -261,11 +259,11 @@ public class ActorRegistryTest {
     @Test
     public void testAskByTypeAndOptionalName() {
         new DebugTimingTestKit(testKit.actorSystem()) {{
-            Future<TestResponse> future = lookup.lookup(Optional.of("TestActor"), TestResponse.class)
+            CompletionStage<TestResponse> stage = lookup.lookup(Optional.of("TestActor"), TestResponse.class)
                     .ask(new TestRequest("ActorLookup[TestResponse]('TestActor')"), askTimeout());
             try {
-                TestResponse result = Await.result(future, awaitMax());
-                assertEquals(new TestResponse("ActorLookup[TestResponse]('TestActor')"), result);
+                assertEquals(new TestResponse("ActorLookup[TestResponse]('TestActor')"),
+                        stage.toCompletableFuture().get());
             } catch (Exception e) {
                 fail("Awaiting for response");
             }


### PR DESCRIPTION
Change ActorLookup japi ask to return CompletionStage instead
of Scala Future.


Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [x] Documentation added/updated.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
