### PR TITLE
 #464: graphstage for demand/supply metrics

### DIFF
--- a/squbs-ext/src/main/scala/org/squbs/streams/DemandSupplyMetrics.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/DemandSupplyMetrics.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.stream._
+import akka.stream.scaladsl.Flow
+import akka.stream.stage._
+import com.codahale.metrics.MetricRegistry
+import org.squbs.metrics.MetricsExtension
+
+object DemandSupplyMetrics {
+
+  /**
+    * Creates a linear [[GraphStage]] that captures (downstream) demand and (upstream) supply metrics.
+    *
+    * @tparam T the type of the elements flowing from upstream to downstream
+    * @param name A name to identify this instance's metric
+    * @param system The Actor system
+    * @return a [[DemandSupplyMetricsStage]] that can be joined with a [[Flow]] with the corresponding type to capture
+    *         demand/supply metrics.
+    */
+  def apply[T](name: String)(implicit system: ActorSystem): DemandSupplyMetricsStage[T] =
+    new DemandSupplyMetricsStage[T](name)
+}
+
+/**
+  * A linear [[GraphStage]] that is used to capture (downstream) demand and (upstream) supply metrics for
+  * backpressure visibility.
+  */
+class DemandSupplyMetricsStage[T](name: String)(implicit system: ActorSystem) extends GraphStage[FlowShape[T, T]] {
+
+  val domain = MetricsExtension(system).Domain
+  val metrics = MetricsExtension(system).metrics
+
+  val in = Inlet[T](Logging.simpleName(this) + ".in")
+  val out = Outlet[T](Logging.simpleName(this) + ".out")
+
+  override val shape = FlowShape.of(in, out)
+
+  // naming convention "domain:key-property-list"
+  val upstreamCounter = MetricRegistry.name(domain, s"$name-upstream-counter")
+  val downstreamCounter = MetricRegistry.name(domain, s"$name-downstream-counter")
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) {
+
+      setHandler(in, new InHandler {
+        override def onPush(): Unit = {
+          val elem = grab(in)
+          metrics.meter(upstreamCounter).mark
+          push(out, elem)
+        }
+      })
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit = {
+          metrics.meter(downstreamCounter).mark
+          pull(in)
+        }
+      })
+    }
+
+}

--- a/squbs-ext/src/test/scala/org/squbs/streams/DemandSupplyMetricsSpec.scala
+++ b/squbs-ext/src/test/scala/org/squbs/streams/DemandSupplyMetricsSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import java.lang.management.ManagementFactory
+import javax.management.ObjectName
+
+import akka.actor.ActorSystem
+import akka.stream.ThrottleMode.Shaping
+import akka.stream.scaladsl._
+import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.testkit.TestKit
+import org.scalatest.{AsyncFlatSpecLike, Matchers}
+import org.squbs.metrics.MetricsExtension
+
+import scala.concurrent.duration._
+
+class DemandSupplyMetricsSpec extends TestKit(ActorSystem("DemandSupplyMetricsSpec")) with AsyncFlatSpecLike with Matchers {
+
+  implicit val materializer = ActorMaterializer()
+
+  it should "throttle demand" in {
+    val name = "test1"
+    val testFlow = DemandSupplyMetrics[Int](name)(system)
+    val result = Source(1 to 10).via(testFlow).throttle(1, 1.second, 1, Shaping).runWith(Sink.ignore)
+    result map { _ =>
+      assert(jmxValue[Long](s"$name-downstream-counter", "Count").get == 10)
+    }
+  }
+
+  it should "require demand >= supply" in {
+    val name = "test2"
+    val testFlow = DemandSupplyMetrics[Int](name)(system)
+    val result = Source(1 to 100000).via(testFlow).throttle(10000, 1.second, 10000, Shaping).runWith(Sink.ignore)
+
+    result map { _ =>
+      assert(jmxValue[Long](s"$name-upstream-counter", "Count").get == 100000)
+      val downstreamCount = jmxValue[Long](s"$name-downstream-counter", "Count").get
+      assert(downstreamCount == 100000 || downstreamCount == 100001)
+    }
+  }
+
+  it should "report metrics correctly with buffering and throttling" in {
+    val name = "test3"
+
+    val preFlow = DemandSupplyMetrics[Int](s"$name-pre")(system)
+    val postFlow = DemandSupplyMetrics[Int](s"$name-post")(system)
+
+    val result = Source(1 to 100)
+      .via(preFlow)
+      .throttle(10, 1.second, 10, Shaping)
+      .buffer(2, OverflowStrategy.backpressure)
+      .throttle(20, 1.second, 20, Shaping)
+      .via(postFlow)
+      .runWith(Sink.ignore)
+
+    result map { _ =>
+      assert(jmxValue[Long](s"$name-pre-upstream-counter", "Count").get == 100)
+      assert(jmxValue[Long](s"$name-pre-downstream-counter", "Count").get == 100)
+
+      assert(jmxValue[Long](s"$name-post-upstream-counter", "Count").get == 100)
+      assert(jmxValue[Long](s"$name-post-downstream-counter", "Count").get == 101)
+    }
+  }
+
+  it should "report metrics correctly with buffering and upstream throttle" in {
+    val name = "test4"
+
+    val preFlow = DemandSupplyMetrics[Int](s"$name-pre")(system)
+    val postFlow = DemandSupplyMetrics[Int](s"$name-post")(system)
+
+    val result = Source(1 to 100)
+      .via(preFlow)
+      .buffer(2, OverflowStrategy.backpressure)
+      .throttle(20, 1.second, 20, Shaping)
+      .via(postFlow)
+      .runWith(Sink.ignore)
+
+    result map { _ =>
+      assert(jmxValue[Long](s"$name-pre-upstream-counter", "Count").get == 100)
+      assert(jmxValue[Long](s"$name-pre-downstream-counter", "Count").get == 100)
+
+      assert(jmxValue[Long](s"$name-post-upstream-counter", "Count").get == 100)
+      assert(jmxValue[Long](s"$name-post-downstream-counter", "Count").get == 101)
+    }
+  }
+
+  it should "report metrics correctly with multiple materializations" in {
+    val name = "test5"
+
+    val dsMetric = DemandSupplyMetrics[Int](s"$name")(system)
+    val flow = Source(1 to 10)
+      .via(dsMetric)
+      .buffer(2, OverflowStrategy.backpressure)
+
+    flow.runWith(Sink.ignore) map { _ =>
+      assert(jmxValue[Long](s"$name-upstream-counter", "Count").get == 10)
+      assert(jmxValue[Long](s"$name-downstream-counter", "Count").get == 10)
+    }
+
+    flow.runWith(Sink.ignore) map { _ =>
+      assert(jmxValue[Long](s"$name-upstream-counter", "Count").get >= 20)
+      assert(jmxValue[Long](s"$name-downstream-counter", "Count").get >= 20)
+    }
+  }
+
+  def jmxValue[T](beanName: String, key: String): Option[T] = {
+    val oName =
+      ObjectName.getInstance(s"${MetricsExtension(system).Domain}:name=${MetricsExtension(system).Domain}.$beanName")
+    Option(ManagementFactory.getPlatformMBeanServer.getAttribute(oName, key)).map(_.asInstanceOf[T])
+  }
+
+}


### PR DESCRIPTION
Add a linear graph stage for collecting supply/demand metrics.


Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [ ] Documentation added/updated.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
