### PR TITLE
#480: upgrade copyright year from 2015 to 2017

### DIFF
--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/RegisterContextSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/RegisterContextSpec.scala
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2015 PayPal
+ *  Copyright 2017 PayPal
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
upgrade copyright year from 2015 to 2017

Fixes: https://github.com/paypal/squbs/issues/480

Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
