### PR TITLE
 #417: Add Retry Flow support

### DIFF
--- a/docs/flow-retry.md
+++ b/docs/flow-retry.md
@@ -1,0 +1,169 @@
+# Retry stage
+
+### Overview
+
+Some stream use cases may require retrying of requests after a failure response.  squbs provides a `RetryBidi` Akka Streams stage to add a retry capability to
+ streams that need to add retries for any failing requests.
+
+### Dependency
+
+Add the following dependency to your `build.sbt` or scala build file:
+
+```
+"org.squbs" %% "squbs-ext" % squbsVersion
+```
+
+### Usage
+
+The retry stage functionality is provided via a `BidiFlow` that can be connected to flows via the `join` operator.  The retry `BidiFlow` will perform some
+ specified maximum number of retries of any failures from downstream. A failure is determined by either a passed in failure decider function or a Failure,
+ if a failure decider function is not supplied.
+
+If all the retried attempts fail then the last failure for that request is emitted.  The retry stage requires a `Context` to be carried around for each
+ element.  This is needed to uniquely identify each element (see [Context to Unique Id Mapping](#context-to-unique-id-mapping) section for more details).
+
+##### Scala
+
+```scala
+val retryBidi = RetryBidi[String, Long](maxRetries = 10)
+val flow = Flow[Try[String], Long].map(s => findAnEnglishWordThatStartWith(s))
+
+Source("a" :: "b" :: "c" :: Nil)
+  .via(retryBidi.join(flow))
+  .runWith(Sink.seq)
+```
+
+##### Java
+
+```java
+final BidiFlow<Pair[String, Context], Pair[String, Context],
+    Pair[Try[String], Context], Pair[Try[String], Context], NotUsed> retryBidi =
+    RetryBidi.create(2);
+
+final Flow<String, String, NotUsed> flow =
+    Flow.<String>create().map(s -> findAnEnglishWordThatStartWith(s));
+
+Source.from(Arrays.asList("a", "b", "c"))
+    .via(retryBidi.join(flow))
+    .runWith(Sink.seq(), mat);
+```
+
+#### Context to Unique Id Mapping
+
+The `Context` type itself might be used as a unique id.  However, in many scenarios, `Context` contains more than the unique id itself or the unique id might
+ be retrieved as a mapping from the `Context`.  squbs allows different options to provide a unique id:
+
+   * `Context` itself is a type that can be used as a unique id, e.g., `Int`, `Long`, `java.util.UUID`
+   * `Context` extends `UniqueId.Provider` and implements `def uniqueId`
+   * `Context` is wrapped with `UniqueId.Envelope`
+   * `Context` is mapped to a unique id by calling a function
+
+With the first three options, a unique id can be retrieved directly through the context.
+
+For the last option, `RetryBidi` allows a function to be passed in as a parameter.
+
+###### Scala
+
+The following API can be used to pass a uniqueId mapper:
+
+```scala
+RetryBidi[In, Out, Context](maxRetries: Int, uniqueIdMapper: Context => Option[Any])
+```
+
+This `BidiFlow` can be joined with any flow that takes in a `(In, Context)` and outputs a `(Out, Context)`.
+
+```scala
+case class MyContext(s: String, uuid: UUID)
+
+val retryBidi = RetryBidi[String, String, MyContext](maxRetries = 2, (context: MyContext) => Some(context.uuid))
+val flow = Flow[(String, MyContext)].mapAsyncUnordered(10) { elem =>
+  (ref ? elem).mapTo[(String, MyContext)]
+}
+
+Source("a" :: "b" :: "c" :: Nil)
+  .map( _ -> MyContext("dummy", UUID.randomUUID))
+  .via(retryBidi.join(flow))
+  .runWith(Sink.seq)
+```
+
+###### Java
+
+The following API is used to pass a uniqueId mapper:
+
+```java
+public class RetryBidi {
+    public static <In, Out, Context> BidiFlow<Pair<In, Context>,
+                                              Pair<In, Context>,
+                                              Pair<Try<Out>, Context>,
+                                              Pair<Try<Out>, Context>,
+                                              NotUsed>
+    create(Long maxRetries, Function<Context, Optional<Object>> uniqueIdMapper);
+}
+```
+
+This `BidiFlow` can be joined with any flow that takes in a `akka.japi.Pair<In, Context>` and outputs a `akka.japi.Pair<Try<Out>, Context>`.
+
+```java
+class MyContext {
+    private String s;
+    private UUID uuid;
+
+    public MyContext(String s, UUID uuid) {
+        this.s = s;
+        this.uuid = uuid;
+    }
+
+    public UUID uuid() {
+        return uuid;
+    }
+};
+
+final BidiFlow<Pair<String, MyContext>, Pair<String, MyContext>,
+               Pair<Try<String>, MyContext>, Pair<Try<String>, MyContext>, NotUsed>
+                retryBidi = RetryBidi.create(maxRetries, context -> Optional.of(context.uuid));
+
+final Flow<Pair<String, MyContext>, Pair<String, MyContext>, NotUsed> flow =
+        Flow.<Pair<String, MyContext>>create()
+                .mapAsyncUnordered(10, elem -> ask(ref, elem, 5000))
+                .map(elem -> (Pair<String, MyContext>)elem);
+
+Source.from(Arrays.asList("a", "b", "c"))
+        .map(s -> new Pair<>(s, new MyContext("dummy", UUID.randomUUID())))
+        .via(retryBidi.join(flow))
+        .runWith(Sink.seq(), mat);
+
+```
+
+#### Failure decider
+
+By default, any `Failure` from the joined `Flow` is considered a failure for retry purposes.  However, the `Retry` stage also accepts an optional
+ `failureDecider` parameter to more finely control what elements from the joined `Flow` should actually be treated as failures that should be retried.
+
+##### Scala
+
+A function of type `Try[Out] => Boolean` can be provided via the `failureDecider` parameter. Below is an example where, along with any `Failure` message,
+Any response with failing http status code is also considered a failure:
+
+```scala
+
+val failureDecider = (tryResponse: Try[HttpResponse]) => tryResponse.isFailure || tryResponse.get().status().isFailure()
+
+val retryBidi = RetryBidi[Request, Response, MyContext](maxRetries = 3, (context: MyContext) => Some(context.uuid), failureDecider = Option(failureDecider), OverflowStrategy.backpressure())
+
+```
+
+##### Java
+
+A `Function<Try<Out>, Boolean>` can be provided via Retry Optional `failureDecider` parameter to create method.  Below is an example where,
+along with any `Failure` message, a `Success` of `HttpResponse` with status code `400` and above is also considered a failure:
+
+```java
+
+final Function<Try<HttpResponse>, Optional<Object>> failureDecider =
+tryResponse -> tryResponse.isFailure() || tryHttpResponse.get().status().isFailure());
+
+final BidiFlow<Pair<HttpResponse, MyContext>, Pair<HttpResponse, MyContext>, Pair<Try<HttpResponse>, MyContext>,
+    Pair<Try<HttpResponse>, MyContext>, NotUsed> retryFlow =
+    RetryBidi.create(3L, Optional.of(failureDecider), OverflowStrategy.backpressure());
+
+```

--- a/docs/flow-timeout.md
+++ b/docs/flow-timeout.md
@@ -1,4 +1,4 @@
-# Timeout Flow
+# Timeout stage
 
 ### Overview
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,39 @@
+site_name: squbs
+theme: readthedocs
+repo_url: https://github.com/paypal/squbs
+edit_uri: blob/master/docs/
+pages:
+- Overview: 'index.md'
+- About:
+    - 'Contributing': 'CONTRIBUTING.md'
+    - 'License': 'LICENSE.txt'
+    - 'Presentations': 'presentations.md'
+- Documentation:
+    - 'Principles of squbs Design': 'principles_of_the_squbs_design.md'
+    - 'Unicomplex & Cube Bootstrapping': 'bootstrap.md'
+    - 'Unicomplex Actor Hierarchy': 'actor-hierarchy.md'
+    - 'Runtime Lifecycle & API': 'lifecycle.md'
+    - 'Implementing HTTP(S) Services': 'http-services.md'
+    - 'Akka HTTP Client on Steroids': 'httpclient.md'
+    - 'Request/Response Pipeline': 'pipeline.md'
+    - 'Marshalling and Unmarshalling': 'marshalling.md'
+    - 'Configuration': 'configuration.md'
+    - 'Testing squbs Applications': 'testing.md'
+    - 'Clustering squbs Services using ZooKeeper': 'zkcluster.md'
+    - 'Blocking Dispatcher': 'blocking-dispatcher.md'
+    - 'Message Guidelines': 'messages.md'
+    - 'Actor Monitor': 'monitor.md'
+    - 'Orchestration DSL': 'orchestration_dsl.md'
+    - 'Actor Registry': 'registry.md'
+    - 'Admin Console': 'console.md'
+    - 'Application Lifecycle Management': 'packaging.md'
+    - 'Resource Resolution': 'resolver.md'
+    - 'Akka Streams GraphStages':
+        - 'Persistent Buffer': 'persistent-buffer.md'
+        - 'Perpetual Stream': 'streams-lifecycle.md'
+        - 'Circuit Breaker': 'circuitbreaker.md'
+        - 'Timeout': 'flow-timeout.md'
+        - 'Deduplicate': 'deduplicate.md'
+        - 'Retry': 'flow-retry.md'
+    - 'Timeout Policy': 'timeoutpolicy.md'
+    - 'Validation': 'validation.md'

--- a/squbs-ext/build.sbt
+++ b/squbs-ext/build.sbt
@@ -24,6 +24,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4" % "optional",
   "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonV % "optional",
   "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
+  "com.typesafe.akka" %% "akka-stream-testkit" % akkaV % "test",
   "junit" % "junit" % junitV % "test",
   "com.novocode" % "junit-interface" % junitInterfaceV % "test->default",
   "org.scalatest" %% "scalatest" % scalatestV % "test->*"

--- a/squbs-ext/src/main/scala/org/squbs/streams/RetryBidi.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/RetryBidi.scala
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2017 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import java.util.Optional
+
+import akka.NotUsed
+import akka.http.org.squbs.util.JavaConverters
+import akka.japi.Pair
+import akka.stream.Attributes.InputBuffer
+import akka.stream.scaladsl.{BidiFlow, Flow}
+import akka.stream.stage._
+import akka.stream._
+import akka.stream.OverflowStrategy._
+
+import scala.collection.mutable
+import scala.util.{Failure, Try}
+
+object RetryBidi {
+  /**
+    * Creates a [[BidiFlow]] that can be used to provide Retry functionality.
+    * This API is specifically for flows that are using [[Try]]'s for elements that may occasionally fail.  By default,
+    * any [[Failure]] is considered a failure that should be retried. However, a failureDecider function can be
+    * specified to control what constitutes a failure.
+    *
+    * Retry functionality requires each element passing through this flow to be uniquely identifiable for retrying, so
+    * it requires a [[Context]], of any type carried along with the flow's input and output element as a
+    * [[Tuple2]] (Scala) or [[Pair]] (Java).  The requirement is that either the [[Context]] type itself or a mapping
+    * from [[Context]] should be able to uniquely identify each element passing through flow.
+    *
+    * Here are the ways a unique id can be provided:
+    *
+    *   - [[Context]] itself is a type that can be used as a unique id, e.g., [[Int]], [[Long]], [[java.util.UUID]]
+    *   - [[Context]] extends [[UniqueId.Provider]] and implements [[UniqueId.Provider.uniqueId]] method
+    *   - [[Context]] is of type [[UniqueId.Envelope]]
+    *   - [[Context]] can be mapped to a unique id by calling {{{uniqueIdMapper}}}
+    *
+    * This stage supports a default in-flight maximum number of elements based on stage Attribute InputBuffer max.
+    * This maximum buffer size includes all elements currently failing (and being re-tried) as well as any elements
+    * in-flight.  To increase this size you can update the stage attribute max value for InputBuffer.
+    *
+    * @param maxRetries     the maximum number of retry attempts on any failures before giving up.
+    * @param uniqueIdMapper the function that maps [[Context]] to a unique id
+    * @param failureDecider function to determine if an element passed by the joined [[Flow]] is
+    *                       actually a failure or not
+    * @param overflowStrategy the overflowStrategy to use on Retry buffer filling
+    * @tparam In      the type of elements pulled from upstream along with the [[Context]]
+    * @tparam Out     the type of the elements that are pushed to downstream along with the [[Context]]
+    * @tparam Context the type of the context that is carried along with the elements.
+    * @return a [[BidiFlow]] with Retry functionality
+    */
+  def apply[In, Out, Context](maxRetries: Long, uniqueIdMapper: Context => Option[Any] = (_: Any) => None,
+                              failureDecider: Option[Try[Out] => Boolean] = None,
+                              overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure):
+  BidiFlow[(In, Context), (In, Context), (Try[Out], Context), (Try[Out], Context), NotUsed] =
+    BidiFlow.fromGraph(new RetryBidi(maxRetries, uniqueIdMapper, failureDecider, overflowStrategy))
+
+  import scala.compat.java8.OptionConverters._
+  /**
+    * Java API
+    * Creates a [[akka.stream.javadsl.BidiFlow]] that can be joined with a [[akka.stream.javadsl.Flow]] to add
+    * Retry functionality with uniqueIdMapper, custom failure decider and OverflowStrategy.
+    */
+  def create[In, Out, Context](maxRetries: Long, uniqueIdMapper: java.util.function.Function[Context, Optional[Any]],
+                               failureDecider: Optional[java.util.function.Function[Try[Out], Boolean]],
+                               overflowStrategy: OverflowStrategy):
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Try[Out], Context], Pair[Try[Out], Context], NotUsed] =
+    JavaConverters.toJava(apply[In, Out, Context](maxRetries,
+      uniqueIdMapper = UniqueId.javaUniqueIdMapperAsScala(uniqueIdMapper),
+      failureDecider = failureDecider.asScala.map(f => (out: Try[Out]) => f(out)),
+      overflowStrategy))
+
+  /**
+    * Java API
+    * @see above for details about each parameter
+    */
+  def create[In, Out, Context](maxRetries: Long,
+                               failureDecider: Optional[java.util.function.Function[Try[Out], Boolean]],
+                               overflowStrategy: OverflowStrategy):
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Try[Out], Context], Pair[Try[Out], Context], NotUsed] =
+    JavaConverters.toJava(apply[In, Out, Context](maxRetries,
+      failureDecider = failureDecider.asScala.map(f => (out: Try[Out]) => f(out)),
+      overflowStrategy = overflowStrategy))
+
+  /**
+    * Java API
+    * @see above for details about each parameter.
+    */
+  def create[In, Out, Context](maxRetries: Long, uniqueIdMapper: java.util.function.Function[Context, Optional[Any]],
+                               overflowStrategy: OverflowStrategy):
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Try[Out], Context], Pair[Try[Out], Context], NotUsed] =
+    JavaConverters.toJava(apply[In, Out, Context](maxRetries,
+      uniqueIdMapper = UniqueId.javaUniqueIdMapperAsScala(uniqueIdMapper),
+      overflowStrategy = overflowStrategy))
+
+  /**
+    * Java API
+    * @see above for details about each parameter.
+    */
+  def create[In, Out, Context](maxRetries: Long):
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Try[Out], Context], Pair[Try[Out], Context], NotUsed] =
+    JavaConverters.toJava(apply[In, Out, Context](maxRetries))
+}
+
+/**
+  * A bidi [[GraphStage]] that can be joined with flows that produce [[Try]]'s to add Retry functionality
+  * when there are any failures.  When the joined [[Flow]] has a failure then based on the provided
+  * max retries count, it will retry the failures.
+  *
+  * '''Emits when''' a Success is available from joined flow or a failure has been retried the maximum number of retries
+  *
+  * '''Backpressures when''' the element is not a failure and downstream backpressures or the retry buffer is full
+  *
+  * '''Completes when''' upstream completes
+  *
+  * '''Cancels when''' downstream cancels
+  *
+  * {{{
+  *          upstream      +------+      downstream
+  *       (In, Context) ~> |      | ~> (In, Context)
+  *            In1         | bidi |        Out1
+  * (Try[Out], Context) <~ |      | <~ (Try[Out], Context)
+  *           Out2         +------+        In2
+  * }}}
+  *
+  * @param maxRetries maximum number of retry attempts on any failing [[Try]]'s
+  * @param uniqueIdMapper function that maps a [[Context]] to a unique value per element
+  * @param failureDecider function that gets called to determine if an element passed by the joined [[Flow]] is a
+  *                       failure
+  * @tparam In the type of elements pulled from the upstream along with the [[Context]]
+  * @tparam Out the type of the elements that are pushed by the joined [[Flow]] along with the [[Context]].
+  *             This then gets wrapped with a [[Try]] and pushed downstream with a [[Context]]
+  * @tparam Context the type of the context that is carried around along with the elements.
+  */
+final class RetryBidi[In, Out, Context] private[streams](maxRetries: Long, uniqueIdMapper: Context => Option[Any],
+                                                         failureDecider: Option[Try[Out] => Boolean] = None,
+                                                         strategy: OverflowStrategy = OverflowStrategy.backpressure)
+  extends GraphStage[BidiShape[(In, Context), (In, Context), (Try[Out], Context), (Try[Out], Context)]] {
+
+  require(maxRetries > 0)
+
+  private val in1 = Inlet[(In, Context)]("RetryBidi.in1")
+  private val out1 = Outlet[(In, Context)]("RetryBidi.out1")
+  private val in2 = Inlet[(Try[Out], Context)]("RetryBidi.in2")
+  private val out2 = Outlet[(Try[Out], Context)]("RetryBidi.out2")
+  override val shape = BidiShape(in1, out1, in2, out2)
+
+  private[streams] def uniqueId(context: Context) =
+    uniqueIdMapper(context).getOrElse {
+      context match {
+        case uniqueIdProvider: UniqueId.Provider ⇒ uniqueIdProvider.uniqueId
+        case `context` ⇒ `context`
+      }
+    }
+
+  private[streams] val isFailure = failureDecider.getOrElse((e: Try[Out]) => e.isFailure)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape)
+    with StageLogging {
+
+    val internalBufferSize: Int =
+      inheritedAttributes.get[InputBuffer] match {
+        case None ⇒ throw new IllegalStateException(s"Couldn't find InputBuffer Attribute for $this")
+        case Some(InputBuffer(_, max)) ⇒ max
+      }
+
+    // A map of all the in flight (including failed) in elements with their retry count (bounded by size)
+    private val retryRegistry = mutable.LinkedHashMap.empty[Any, (In, Context, Long)]
+    private val readyToRetry = mutable.Queue.empty[(In, Context)] // Queue of elements ready to be emitted on out1
+    private var upstreamFinished = false
+
+    private def incrementOrRemoveFailure(context: Context): Boolean =
+      retryRegistry.get(uniqueId(context)) match {
+        case None =>
+          log.debug("Entry for context [{}] dropped", context)
+          true
+        case Some((_, ctx, retry)) if retry >= maxRetries =>
+          retryRegistry -= uniqueId(ctx)
+          log.debug("All retries exhausted for context [{}]", context)
+          true
+        case Some((in, ctx, retry)) =>
+          retryRegistry += ((uniqueId(context), (in, ctx, retry + 1)))
+          readyToRetry.enqueue((in, context))
+          log.debug("Queueing retry {} for context [{}]", retry + 1, context)
+          false
+      }
+
+    // Some useful hidden types for pattern match
+    private val backPressure = OverflowStrategy.backpressure
+    private val dropBuffer = OverflowStrategy.dropBuffer
+    private val dropHead = OverflowStrategy.dropHead
+    private val dropNew = OverflowStrategy.dropNew
+    private val dropTail = OverflowStrategy.dropTail
+    private val fail = OverflowStrategy.fail
+
+    private def handleBufferFull(): Unit = strategy match {
+      case `dropHead` =>
+        retryRegistry -= retryRegistry.head._1 // build a Buffer for squbs
+        log.debug("Buffer full dropping head")
+        grabAndPush()
+      case `dropNew` =>
+        grab(in1)
+        log.debug("Buffer full dropping newest")
+      case `dropTail` =>
+        retryRegistry -= retryRegistry.last._1
+        log.debug("Buffer full dropping last")
+        grabAndPush()
+      case `dropBuffer` =>
+        retryRegistry.clear()
+        log.debug("Buffer full dropping buffer")
+        grabAndPush()
+      case `fail` =>
+        failStage(BufferOverflowException(s"Retry buffer overflow for retry stage (max capacity was: $internalBufferSize)!"))
+      case `backPressure` =>
+        // NOP.  Don't grab any elements from upstream in backpressure mode when full
+      case _ ⇒
+        throw new IllegalStateException("Retry buffer overflow mode not supported")
+    }
+
+    private def pullCondition: Boolean = strategy != backpressure || retryRegistry.size < internalBufferSize
+    private def isBufferFull: Boolean = retryRegistry.size >= internalBufferSize
+
+    def grabAndPush(): Unit = {
+      val (elem, context) = grab(in1)
+      retryRegistry.put(uniqueId(context), (elem, context, 0))
+      push(out1, (elem, context))
+    }
+
+    setHandler(in1, new InHandler {
+      override def onPush(): Unit = {
+        if (isAvailable(out1)) {
+          if (isBufferFull) handleBufferFull()
+          else grabAndPush()
+        }
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        if (retryRegistry.isEmpty) completeStage()
+        upstreamFinished = true
+      }
+
+      override def onUpstreamFailure(ex: Throwable): Unit = if (retryRegistry.isEmpty) fail(out1, ex) else failStage(ex)
+    })
+
+    setHandler(out1, new OutHandler {
+      override def onPull(): Unit = {
+        if (readyToRetry.nonEmpty) push(out1, readyToRetry.dequeue())
+        else if (isAvailable(in1)) {
+          if (isBufferFull) handleBufferFull()
+          else grabAndPush()
+        } else if (pullCondition && !upstreamFinished && !hasBeenPulled(in1)) pull(in1)
+      }
+
+      override def onDownstreamFinish(): Unit =
+        if (retryRegistry.isEmpty) {
+          completeStage()
+          log.debug("completed Out1")
+        } else cancel(in1)
+    })
+
+    setHandler(in2, new InHandler {
+      override def onPush(): Unit = {
+        val (elem, context) = grab(in2)
+        if (isFailure(elem)) {
+          if (incrementOrRemoveFailure(context)) push(out2, (elem, context))
+          else if (isAvailable(out1)) push(out1, readyToRetry.dequeue())
+          if (retryRegistry.nonEmpty) pull(in2)
+        } else {
+          retryRegistry.remove(uniqueId(context))
+          push(out2, (elem, context))
+        }
+      }
+
+      override def onUpstreamFailure(ex: Throwable): Unit = if (readyToRetry.isEmpty) fail(out2, ex)
+    })
+
+    setHandler(out2, new OutHandler {
+      override def onPull(): Unit =
+        if (retryRegistry.isEmpty && upstreamFinished) completeStage()
+        else if (!hasBeenPulled(in2)) pull(in2)
+
+      override def onDownstreamFinish(): Unit =
+        if (retryRegistry.isEmpty) {
+          completeStage()
+          log.debug("completed Out2")
+        } else cancel(in2)
+
+    })
+  }
+
+  override def toString: String = "RetryBidi"
+
+}

--- a/squbs-ext/src/main/scala/org/squbs/streams/TimeoutBidi.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/TimeoutBidi.scala
@@ -197,7 +197,7 @@ object TimeoutBidiFlowUnordered {
   def create[In, Out, Context](timeout: FiniteDuration,
                                uniqueIdMapper: java.util.function.Function[Context, Optional[Any]],
                                cleanUp: Consumer[Out]):
-  akka.stream.javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
     toJava(apply(timeout, UniqueId.javaUniqueIdMapperAsScala(uniqueIdMapper), toScala(cleanUp)))
   }
 
@@ -206,7 +206,7 @@ object TimeoutBidiFlowUnordered {
     */
   def create[In, Out, Context](timeout: FiniteDuration,
                                uniqueIdMapper: java.util.function.Function[Context, Optional[Any]]):
-  akka.stream.javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
     toJava(apply[In, Out, Context](timeout, UniqueId.javaUniqueIdMapperAsScala(uniqueIdMapper)))
   }
 
@@ -215,7 +215,7 @@ object TimeoutBidiFlowUnordered {
     */
   def create[In, Out, Context](timeout: FiniteDuration,
                                cleanUp: Consumer[Out]):
-  akka.stream.javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
     toJava(apply(timeout = timeout, cleanUp = toScala(cleanUp)))
   }
 
@@ -223,7 +223,7 @@ object TimeoutBidiFlowUnordered {
     * Java API
     */
   def create[In, Out, Context](timeout: FiniteDuration):
-  akka.stream.javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
+  javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] = {
     toJava(apply[In, Out, Context](timeout))
   }
 }

--- a/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/CircuitBreakerBidi.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/CircuitBreakerBidi.scala
@@ -220,7 +220,7 @@ object CircuitBreakerBidiFlow {
   * @param circuitBreakerState the [[CircuitBreakerState]] implementation that holds the state of the circuit breaker
   * @param fallback the function that gets called to provide an alternative response when the circuit is OPEN
   * @param cleanUp an optional clean up function to be applied on timed out elements when pushed
-  * @param failureDecider the function that gets called to determine if an element passed by the joined [[Flow]] is
+  * @param failureDecider the function that gets called to determine if an element pased by the joined [[Flow]] is
   *                       actually a failure or not
   * @param uniqueIdMapper the function that maps [[Context]] to a unique id
   * @tparam In the type of the elements pulled from the upstream along with the [[Context]] and pushed down to joined

--- a/squbs-ext/src/test/java/org/squbs/streams/RetryBidiTest.java
+++ b/squbs-ext/src/test/java/org/squbs/streams/RetryBidiTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.OverflowStrategy;
+import akka.stream.javadsl.BidiFlow;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import org.testng.annotations.Test;
+import scala.util.Failure;
+import scala.util.Success;
+import scala.util.Try;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class RetryBidiTest {
+
+    final private ActorSystem system = ActorSystem.create("RetryBidiTest");
+    final private Materializer mat = ActorMaterializer.create(system);
+    final private Try<String> failure = Failure.apply(new Exception("failed"));
+
+    @Test
+    public void testRetryBidi() throws ExecutionException, InterruptedException {
+
+        final Flow<Pair<String, UUID>, Pair<Try<String>, UUID>, NotUsed> flow =
+                Flow.<Pair<String, UUID>>create()
+                        .map(elem -> new Pair<Try<String>, UUID>(Success.apply(elem.first()), elem.second()));
+
+        final BidiFlow<Pair<String, UUID>, Pair<String, UUID>, Pair<Try<String>, UUID>, Pair<Try<String>, UUID>, NotUsed> retry =
+                RetryBidi.create(2L);
+
+        final CompletionStage<List<Try<String>>> result =
+                Source.from(Arrays.asList("a", "b", "c"))
+                        .map(s -> new Pair<>(s, UUID.randomUUID()))
+                        .via(retry.join(flow))
+                        .map(Pair::first)
+                        .runWith(Sink.seq(), mat);
+
+        final List<Try<String>> expected = Arrays.asList(Success.apply("a"), Success.apply("b"), Success.apply("c"));
+        List<Try<String>> actual = result.toCompletableFuture().get();
+        assertEquals(actual.size(), 3);
+        assertTrue(actual.containsAll(expected), "Did not get the expected elements from retry stage");
+    }
+
+    @Test
+    public void testRetryBidiWithFailures() throws ExecutionException, InterruptedException {
+
+        final Flow<Pair<String, UUID>, Pair<Try<String>, UUID>, NotUsed> bottom =
+                Flow.<Pair<String, UUID>>create()
+                        .map(elem -> {
+                            if (elem.first().equals("a") || elem.first().equals("c"))
+                                return new Pair<>(failure, elem.second());
+                            else
+                                return new Pair<>(Success.apply(elem.first()), elem.second());
+                            });
+        final BidiFlow<Pair<String, UUID>, Pair<String, UUID>, Pair<Try<String>, UUID>, Pair<Try<String>, UUID>, NotUsed> retry =
+                RetryBidi.create(2L);
+
+        final CompletionStage<List<Try<String>>> result =
+                Source.from(Arrays.asList("a", "b", "c"))
+                        .map(s -> new Pair<>(s, UUID.randomUUID()))
+                        .via(retry.join(bottom))
+                        .map(Pair::first)
+                        .runWith(Sink.seq(), mat);
+
+        final List<Try<String>> expected = Arrays.asList(failure, Success.apply("b"), failure);
+        List<Try<String>> actual = result.toCompletableFuture().get();
+        assertEquals(actual.size(), 3);
+        assertTrue(actual.containsAll(expected), "Did not get the expected elements from retry stage");
+    }
+
+    @Test
+    public void testRetryBidiWithRetryFlow() throws ExecutionException, InterruptedException {
+
+        final Flow<Pair<String, UUID>, Pair<Try<String>, UUID>, NotUsed> flow =
+                Flow.<Pair<String, UUID>>create()
+                        .map(elem -> new Pair<Try<String>, UUID>(Success.apply(elem.first()), elem.second()));
+
+        final BidiFlow<Pair<String, UUID>, Pair<String, UUID>, Pair<Try<String>, UUID>, Pair<Try<String>, UUID>, NotUsed> retry =
+                RetryBidi.create(3L);
+
+        final CompletionStage<List<Try<String>>> result =
+                Source.from(Arrays.asList("a", "b", "c"))
+                        .map(s -> new Pair<>(s, UUID.randomUUID()))
+                        .via(retry.join(flow))
+                        .map(Pair::first)
+                        .runWith(Sink.seq(), mat);
+
+        final List<Try<String>> expected = Arrays.asList(Success.apply("a"), Success.apply("b"), Success.apply("c"));
+        List<Try<String>> actual = result.toCompletableFuture().get();
+        assertEquals(actual.size(), 3);
+        assertTrue(actual.containsAll(expected), "Did not get the expected elements from retry stage");
+    }
+
+    @Test
+    public void testRetryBidiWithUniqueIdMapper() throws ExecutionException, InterruptedException {
+
+        class MyContext {
+            private String s;
+            private UUID uuid;
+
+            public MyContext(String s, UUID uuid) {
+                this.s = s;
+                this.uuid = uuid;
+            }
+        }
+        final Flow<Pair<String, MyContext>, Pair<Try<String>, MyContext>, NotUsed> bottom = Flow.<Pair<String, MyContext>>create()
+            .map(elem -> {
+                if (elem.first().equals("b"))
+                    return new Pair<>(failure, elem.second());
+                else
+                    return new Pair<>(Success.apply(elem.first()), elem.second());
+            });
+
+        Function<MyContext, Optional<Object>> uniqueIdMapper = context -> Optional.of(context.uuid);
+        final BidiFlow<Pair<String, MyContext>, Pair<String, MyContext>, Pair<Try<String>, MyContext>,
+                Pair<Try<String>, MyContext>, NotUsed> retryFlow =
+                RetryBidi.create(3L, uniqueIdMapper, OverflowStrategy.backpressure());
+
+        final CompletionStage<List<Try<String>>> result =
+                Source.from(Arrays.asList("a", "b", "c"))
+                        .map(s -> new Pair<>(s, new MyContext("dummy", UUID.randomUUID())))
+                        .via(retryFlow.join(bottom))
+                        .map(t -> t.first())
+                        .runWith(Sink.seq(), mat);
+
+        final List<Try<String>> expected = Arrays.asList(Success.apply("a"), Success.apply("c"), failure);
+        assertTrue(result.toCompletableFuture().get().containsAll(expected),
+                "Did not get the expected elements from retry stage");
+    }
+
+}

--- a/squbs-ext/src/test/scala/org/squbs/streams/RetryBidiSpec.scala
+++ b/squbs-ext/src/test/scala/org/squbs/streams/RetryBidiSpec.scala
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2017 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.streams
+
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.Attributes.inputBuffer
+import akka.stream.{ActorMaterializer, BufferOverflowException, OverflowStrategy}
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.testkit.TestKit
+import org.scalatest.{AsyncFlatSpecLike, Matchers}
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlatSpecLike with Matchers {
+
+  implicit val materializer = ActorMaterializer()
+  val failure = Failure(new Exception("failed"))
+
+  it should "require failure retryCount > 0" in {
+    an[IllegalArgumentException] should be thrownBy
+      RetryBidi[String, String, NotUsed](-1)
+  }
+
+  it should "return all expected elements if no failures" in {
+    val flow = Flow[(String, Long)].map {
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+    val retryBidi = RetryBidi[String, String, Long](1)
+
+    var context = 0L
+    val result = Source("a" :: "b" :: "c" :: Nil)
+      .map { s => context += 1; (s, context) }
+      .via(retryBidi.join(flow))
+      .runWith(Sink.seq)
+
+    val expected = (Success("a"), 1) :: (Success("b"), 2) :: (Success("c"), 3) :: Nil
+    result map {
+      _ should contain theSameElementsAs expected
+    }
+  }
+
+  it should "emit when first fail retries are exhausted" in {
+    val flow = Flow[(String, Long)].map {
+      case ("a", ctx) => (failure, ctx)
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+    var context = 0L
+    val result = Source("a" :: "b" :: "c" :: Nil)
+      .map { e => context += 1; (e, context) }
+      .via(RetryBidi[String, String, Long](3).join(flow))
+      .runWith(Sink.seq)
+
+    val expected = (Success("b"), 2) :: (Success("c"), 3) :: (failure, 1) :: Nil
+    result map {
+      _ should contain theSameElementsAs expected
+    }
+  }
+
+  it should "return failure if middle element failure exhausts retries" in {
+    val flow = Flow[(String, Long)].map {
+      case ("e", ctx) => (failure, ctx)
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+
+    val retryBidi = RetryBidi[String, String, Long](3)
+
+    var context = 0L
+    val result = Source("d" :: "e" :: "f" :: Nil)
+      .map { s => context += 1; (s, context) }
+      .via(retryBidi.join(flow))
+      .runWith(Sink.seq)
+
+    val expected = (Success("d"), 1) :: (failure, 2) :: (Success("f"), 3) :: Nil
+    result map {
+      _ should contain theSameElementsAs expected
+    }
+  }
+
+  it should "return failure if last failure exhausts retries" in {
+    val flow = Flow[(String, Long)].map {
+      case ("f", ctx) => (failure, ctx)
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+
+    val retryBidi = RetryBidi[String, String, Long](1)
+
+    var context = 0L
+    val result = Source("d" :: "e" :: "f" :: Nil)
+      .map { s => context += 1; (s, context) }
+      .via(retryBidi.join(flow))
+      .runWith(Sink.seq)
+
+    val expected = (Success("d"), 1) :: (Success("e"), 2) :: (failure, 3) :: Nil
+    result map {
+      _ should contain theSameElementsAs expected
+    }
+  }
+
+  it should "return exhausted failures in expected FIFO order" in {
+    val flow = Flow[(String, Long)].map {
+      case ("f", ctx) => (failure, ctx)
+      case ("e", ctx) => (failure, ctx)
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+
+    val retryBidi = RetryBidi[String, String, Long](1)
+
+    var context = 0L
+    val result = Source("d" :: "e" :: "f" :: Nil)
+      .map { s => context += 1; (s, context) }
+      .via(retryBidi.join(flow))
+      .runWith(Sink.seq)
+
+    val expected = (Success("d"), 1) :: (failure, 2) :: (failure, 3) :: Nil
+    result map {
+      _ should contain theSameElementsInOrderAs expected
+    }
+  }
+
+  it should "perform the correct number of retries" in {
+    val count = new AtomicLong(0)
+    val flow = Flow[(String, Long)].map {
+      case (_, ctx) => count.getAndIncrement(); (failure, ctx)
+    }
+
+    val maxRetry = 10L
+    val retryBidi = RetryBidi[String, String, Long](maxRetry)
+
+    val context = 42L
+    val result = Source("x" :: Nil)
+      .map { s => (s, context) }
+      .via(retryBidi.join(flow))
+      .runWith(Sink.seq)
+
+    result map { r =>
+      r should contain theSameElementsAs (failure, 42) :: Nil
+      count.get shouldEqual maxRetry + 1
+    }
+  }
+
+  it should "return Success when a failure is retried successfully" in {
+    var first = true
+    val flow = Flow[(String, Long)].map {
+      case ("y", ctx) if first =>
+        first = false
+        (failure, ctx)
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+
+    val retryBidi = RetryBidi[String, String, Long](2)
+
+    var context = 0L
+    val result = Source("x" :: "y" :: "z" :: Nil)
+      .map { s => context += 1; (s, context) }
+      .via(retryBidi.join(flow))
+      .runWith(Sink.seq)
+
+    val expected = (Success("x"), 1) :: (Success("z"), 3) :: (Success("y"), 2) :: Nil
+    result map {
+      _ should contain theSameElementsAs expected
+    }
+  }
+
+  it should "allow a uniqueid mapper via UniqueId.Provider" in {
+
+    case class MyContext(id: Long) extends UniqueId.Provider {
+      override def uniqueId: Any = id
+    }
+
+    val flow = Flow[(String, MyContext)].map {
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+    val retry = RetryBidi[String, String, MyContext](2, uniqueIdMapper = (context: MyContext) => Some(context.uniqueId))
+
+    var counter = 0L
+    val result = Source("a" :: "b" :: "c" :: Nil)
+      .map { s => counter += 1; (s, MyContext(counter)) }
+      .via(retry.join(flow))
+      .map { case (s, _) => s }
+      .runWith(Sink.seq)
+
+    val expected = Success("a") :: Success("b") :: Success("c") :: Nil
+    result map {
+      _ should contain theSameElementsAs expected
+    }
+  }
+
+  it should "cancel upstream if downstream cancels" in {
+    val bottom = Flow[(String, Long)].map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](5)
+    var context = 0L
+    val (source, sink) = TestSource.probe[String]
+      .map { s => context += 1; (s, context) }
+      .via(retry.join(bottom))
+      .toMat(TestSink.probe)(Keep.both).run()
+
+    sink.request(2)
+    source.sendNext("a")
+    sink.cancel()
+    source.expectCancellation()
+    succeed
+  }
+
+  it should "keep retrying after upstream completes" in {
+    val bottom = Flow[(String, Long)].map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](5)
+    var context = 0L
+    val (source, sink) = TestSource.probe[String]
+      .map { s => context += 1; (s, context) }
+      .via(retry.join(bottom))
+      .toMat(TestSink.probe)(Keep.both).run()
+
+    sink.request(1)
+    source.sendNext("a").sendNext("b").sendComplete()
+    val next = sink.requestNext(3 seconds)
+    assert((failure, 1) == next)
+  }
+
+  it should "decide on failures based on the provided function" in {
+    val bottom = Flow[(String, Long)].map {
+      case (elem, ctx) => (Success(elem), ctx)
+    }
+    val failureDecider = (out: Try[String]) => out.isFailure || out.equals(Success("a")) // treat "a" as a failure for retry
+    val retry = RetryBidi[String, String, Long](2, failureDecider = Option(failureDecider))
+
+    var context = 0L
+    val (source, sink) = TestSource.probe[String]
+      .map { s => context += 1; (s, context) }
+      .via(retry.join(bottom))
+      .toMat(TestSink.probe)(Keep.both).run()
+
+    source.sendNext("a").sendNext("b")
+    val nextA = sink.request(1).requestNext()
+    assert((Success("a"), 1) == nextA)
+  }
+
+  it should "drain all elements when upstream finishes" in {
+    val bottom = Flow[(String, Long)].map {
+      case ("1", ctx) => (Success("1"), ctx)
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](10)
+
+    val (source, sink) = TestSource.probe[String]
+      .map(x => (x.toString, x.toLong))
+      .via(retry.join(bottom))
+      .toMat(TestSink.probe)(Keep.both).run()
+
+    source.sendNext("1").sendNext("2").sendNext("3").sendComplete()
+    sink.request(3).expectNext((Success("1"), 1L)).expectNextUnordered((failure, 2L), (failure, 3L))
+    succeed
+  }
+
+  it should "drop head elements and emit them when dropHead buffer mode" in {
+    val bottom = Flow[(String, Long)].delay(10.millis).map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](10, overflowStrategy = OverflowStrategy.dropHead)
+      .withAttributes(inputBuffer(initial = 1, max = 3))
+
+    val sink = Source (1 to 5)
+      .map(x => (x.toString, x.toLong))
+      .via(retry.join(bottom))
+      .runWith(TestSink.probe)
+
+    // 1 and 2 element are emitted after being dropped from buffer, 3-5 after exhausting all retries
+    sink
+      .request(5)
+      .expectNoMsg(10.millis)
+      .expectNext((failure, 1L), (failure, 2L))
+      .expectNoMsg(100.millis)
+      .expectNext((failure, 3L), (failure, 4L), (failure, 5L))
+    succeed
+  }
+
+  it should "drop tail elements and emit them when dropTail buffer mode" in {
+    val bottom = Flow[(String, Long)].delay(10.millis).map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](10, overflowStrategy = OverflowStrategy.dropTail)
+      .withAttributes(inputBuffer(initial = 1, max = 3))
+
+    val sink = Source(1 to 5)
+      .map(x => (x.toString, x.toLong))
+      .via(retry.join(bottom))
+      .runWith(TestSink.probe)
+
+    // element 3 and 4 are emitted after being dropped from buffer
+    sink.request(5)
+      .expectNoMsg(10.millis)
+      .expectNext((failure, 3L), (failure, 4L))
+      .expectNoMsg(100.millis)
+      .expectNext((failure, 1L), (failure, 2L), (failure, 5L))
+    succeed
+  }
+
+  it should "drop new elements when dropNew buffer mode" in {
+    val bottom = Flow[(String, Long)].delay(10.millis).map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](2, overflowStrategy = OverflowStrategy.dropNew)
+      .withAttributes(inputBuffer(initial = 1, max = 3))
+
+    val sink = Source(1 to 5)
+      .map(x => (x.toString, x.toLong))
+      .via(retry.join(bottom))
+      .runWith(TestSink.probe)
+
+    sink.request(5)
+      .expectNext((failure, 1L), (failure, 2L),(failure, 3L))
+      .expectComplete() // element 4 and 5 are dropped on buffer full
+    succeed
+  }
+
+  it should "drop all elements in buffer when dropBuffer mode" in {
+    val bottom = Flow[(String, Long)].delay(10.millis).map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](10, overflowStrategy = OverflowStrategy.dropBuffer)
+      .withAttributes(inputBuffer(initial = 1, max = 4))
+
+    val sink = Source(1 to 8)
+      .map(x => (x.toString, x.toLong))
+      .via(retry.join(bottom))
+      .runWith(TestSink.probe)
+
+    sink.request(8) // first 16 elements are dropped and immitted when buffer is full the rest after exhausting retries
+      .expectNoMsg(10.millis)
+      .expectNext((failure, 1L), (failure, 2L), (failure, 3L), (failure, 4L))
+      .expectNoMsg(100.millis)
+      .expectNext((failure, 5L), (failure, 6L), (failure, 7L), (failure, 8L))
+    succeed
+  }
+
+  it should "backpressures upstream when buffer full" in {
+    val bottom = Flow[(String, Long)].delay(10.millis).map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](1).withAttributes(inputBuffer(initial = 1, max = 1))
+
+    val sink = Source(1 to 3)
+      .map(x => (x.toString, x.toLong))
+      .via(retry.join(bottom))
+      .runWith(TestSink.probe)
+
+    sink.request(3)
+      .expectNoMsg(10.millis)
+      .expectNext((failure, 1L))
+      .expectNoMsg(10.millis)
+    succeed
+  }
+
+  it should "fail when buffer full on fail mode" in {
+    val bottom = Flow[(String, Long)].delay(10.millis).map {
+      case (_, ctx) => (failure, ctx)
+    }
+    val retry = RetryBidi[String, String, Long](1, overflowStrategy = OverflowStrategy.fail)
+      .withAttributes(inputBuffer(initial = 1, max = 1))
+
+    val sink = Source(1 to 3)
+      .map(x => (x.toString, x.toLong))
+      .via(retry.join(bottom))
+      .runWith(TestSink.probe)
+
+    sink.request(3).expectError(new BufferOverflowException("Retry buffer overflow for retry stage (max capacity was: 1)!"))
+    succeed
+  }
+
+  it should "retry with a large data set" in {
+    val bottom = Flow[(Long, Long)].map {
+      case (elem, ctx) => if (ctx % 7 == 0) (failure, ctx) else (Success(elem), ctx) // fail every 7'th element
+    }
+    val retry = RetryBidi[Long, Long, Long](1)
+
+    val result = Source(1L to 10000)
+      .map(x => (x, x))
+      .via(retry.join(bottom))
+      .runWith(Sink.seq)
+
+    val expected = 1 to 10000 map (x => if (x % 7 == 0) (failure, x) else (Success(x), x))
+    result map {
+      _ should contain theSameElementsAs expected
+    }
+  }
+}


### PR DESCRIPTION
Add a retry BIDI flow to support retrying if downstream failures
Add support in retry for a failureDecider to allow clients to customize what constitues failure
Update to use inputbuffer max for upper bound on registry size

(cherry picked from commit b3bb64)


Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [x] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
