### PR TITLE
 #519: Fix high cpu in Circuitbreaker with ClientFlow

### DIFF
--- a/squbs-ext/src/main/scala/org/squbs/streams/TimeoutBidi.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/TimeoutBidi.scala
@@ -334,8 +334,12 @@ final class TimeoutBidiUnordered[In, Out, Context](timeout: FiniteDuration,
       } map { case(id, (context, _)) =>
         timeouts.remove(id)
         (Failure(FlowTimeoutException()), context)
-      } orElse Try(readyToPush.dequeue()).toOption.map { case(elem, _) => elem }
+      } orElse dequeueOption().map { case(elem, _) => elem }
     }
+
+    private def dequeueOption(): Option[((Try[Out], Context), Long)] =
+      if (readyToPush.nonEmpty) Some(readyToPush.dequeue())
+      else None
 
     override protected def onPullOut() = pickNextElemToPush()
 


### PR DESCRIPTION
Avoid un-necessary enqueue followed by dequeue in CircuitBreakerBIDI.


Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [ ] Tests added.
- [x] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
