### PR TITLE
PerpetualStream auto-recognize KillSwitch as materialized value (fixes #574)

### DIFF
--- a/docs/customizing-stream-control.md
+++ b/docs/customizing-stream-control.md
@@ -1,0 +1,107 @@
+# Customizing Stream Control
+
+Akka Streams/Reactive stream needs to be integrated with the [Runtime Lifecycle](lifecycle.md) of the server. For this, an automated or semi-automated integration is provided through the [`PerpetualStream`](perpetualstream.md) infrastructure. If you need even more fine-grained control over stream, the following sections explain such facilities.
+
+### Dependency
+
+In general, you do not need to add an extra dependency. The classes are part of the following dependency:
+
+```scala
+"org.squbs" %% "squbs-unicomplex" % squbsVersion
+```
+
+
+## Making A Lifecycle-Sensitive Source
+
+If you wish to have a source that is fully connected to the lifecycle events of squbs, you can wrap any source with `LifecycleManaged`.
+
+**Scala**
+
+```scala
+val inSource = <your-original-source>
+val aggregatedSource = LifecycleManaged().source(inSource)
+```
+
+**Java**
+
+```java
+final Source inSource = <your-original-source>
+final Source aggregatedSource = new LifecycleManaged(system).source(inSource);
+```
+
+The resulting source will be an aggregated source materialize to a `(T, ActorRef)` where `T` is the materialized type of `inSource` and `ActorRef` is the materialized type of the trigger actor which receives events from the Unicomplex, the squbs container.
+
+The aggregated source does not emit from original source until lifecycle becomes `Active`, and stop emitting element and shuts down the stream after lifecycle state becomes `Stopping`.
+
+## Custom Aggregated Triggered Source
+If you want your flow to enable/disable to custom events, you can integrate with a custom trigger source,
+element `true` will enable, `false` will disable.
+
+Note that `Trigger` takes an argument `eagerComplete` which defaults to `false` in Scala but has to be
+passed in Java. If `eagerComplete` is set to `false`, completion and/or termination of the trigger source actor
+will detach the trigger. If set to `true`, such termination will complete the stream.
+
+##### Scala
+
+```scala
+import org.squbs.stream.TriggerEvent._
+
+val inSource = <your-original-source>
+val trigger = <your-custom-trigger-source>.collect {
+  case 0 => DISABLE
+  case 1 => ENABLE
+}
+
+val aggregatedSource = new Trigger().source(inSource, trigger)
+```
+
+##### Java
+
+```java
+import static org.squbs.stream.TriggerEvent.DISABLE;
+import static org.squbs.stream.TriggerEvent.ENABLE;
+
+final Source<?, ?> inSource = <your-original-source>;
+final Source<?, ?> trigger = <your-custom-trigger-source>.collect(new PFBuilder<Integer, TriggerEvent>()
+    .match(Integer.class, p -> p == 1, p -> ENABLE)
+    .match(Integer.class, p -> p == 0, p -> DISABLE)
+    .build());
+
+final Source aggregatedSource = new Trigger(false).source(inSource, trigger);
+```
+
+## Custom Lifecycle Event(s) for Trigger
+If you want to respond to more lifecycle events beyond `Active` and `Stopping`, for example you want `Failed` to also stop the flow, you can modify the lifecylce event mapping.
+
+##### Scala
+
+```scala
+import org.squbs.stream.TriggerEvent._
+
+val inSource = <your-original-source>
+val trigger = Source.actorPublisher[LifecycleState](Props.create(classOf[UnicomplexActorPublisher]))
+  .collect {
+    case Active => ENABLE
+    case Stopping | Failed => DISABLE
+  }
+
+val aggregatedSource = new Trigger().source(inSource, trigger)
+```
+
+##### Java
+
+```java
+import static org.squbs.stream.TriggerEvent.DISABLE;
+import static org.squbs.stream.TriggerEvent.ENABLE;
+
+final Source<?, ?> inSource = <your-original-source>;
+final Source<?, ActorRef> trigger = Source.<LifecycleState>actorPublisher(Props.create(UnicomplexActorPublisher.class))
+    .collect(new PFBuilder<Integer, TriggerEvent>()
+        .matchEquals(Active.instance(), p -> ENABLE)
+        .matchEquals(Stopping.instance(), p -> DISABLE)
+        .matchEquals(Failed.instance(), p -> DISABLE)
+        .build()
+    );
+
+final Source aggregatedSource = new Trigger(false).source(inSource, trigger);
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,9 +28,10 @@ pages:
     - 'Admin Console': 'console.md'
     - 'Application Lifecycle Management': 'packaging.md'
     - 'Resource Resolution': 'resolver.md'
+    - 'Perpetual Stream': 'perpetualstream.md'
+    - 'Customizing Stream Control': 'customizing-stream-control.md'
     - 'Akka Streams GraphStages':
         - 'Persistent Buffer': 'persistent-buffer.md'
-        - 'Perpetual Stream': 'streams-lifecycle.md'
         - 'Circuit Breaker': 'circuitbreaker.md'
         - 'Timeout': 'flow-timeout.md'
         - 'Deduplicate': 'deduplicate.md'

--- a/squbs-ext/src/main/scala/org/squbs/resolver/Resolver.scala
+++ b/squbs-ext/src/main/scala/org/squbs/resolver/Resolver.scala
@@ -30,6 +30,9 @@ import scala.beans.BeanProperty
 import scala.compat.java8.OptionConverters._
 import scala.reflect._
 
+case class EndpointNotExistsException(name: String, env: Environment) extends Exception {
+  override def getMessage: String = s"Endpoint $name for environment $env not found."
+}
 
 /**
   * Scala API for implementing an EndpointResolver.

--- a/squbs-unicomplex/src/test/java/org/squbs/stream/KillSwitchMatStreamJ.java
+++ b/squbs-unicomplex/src/test/java/org/squbs/stream/KillSwitchMatStreamJ.java
@@ -1,0 +1,60 @@
+package org.squbs.stream;
+
+import akka.japi.Pair;
+import akka.stream.*;
+import akka.stream.javadsl.*;
+import org.squbs.unicomplex.Timeouts;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class KillSwitchMatStreamJ extends AbstractPerpetualStream<Pair<KillSwitch, CompletionStage<Long>>> {
+
+    static final AtomicLong genCount = new AtomicLong(0L);
+
+    Sink<Integer, CompletionStage<Long>> counter = Flow.<Integer>create()
+            .map(l -> 1L)
+            .reduce((i, j) -> i + j)
+            .toMat(Sink.head(), Keep.right());
+
+    @Override
+    public long getStopTimeout() {
+        return Timeouts.awaitMax().toMillis();
+    }
+
+    @Override
+    public RunnableGraph<Pair<KillSwitch, CompletionStage<Long>>> streamGraph() {
+        return RunnableGraph.fromGraph(GraphDSL.create(KillSwitches.<Integer>single(), counter, Pair::create,
+                (builder, kill, sink) -> {
+            SourceShape<Integer> source = builder.add(
+                    Source.unfold(0, i -> {
+                        if (i == Integer.MAX_VALUE) {
+                            genCount.incrementAndGet();
+                            return Optional.of(Pair.create(0, i));
+                        } else {
+                            genCount.incrementAndGet();
+                            return Optional.of(Pair.create(i + 1, i));
+                        }
+                    })
+            );
+
+            FlowShape<Integer, Integer> throttle = builder.add(Flow.<Integer>create().throttle(5000,
+                    FiniteDuration.create(1, TimeUnit.SECONDS), 1000,
+                    ThrottleMode.shaping()));
+
+            builder.from(source).via(kill).via(throttle).to(sink);
+
+            return ClosedShape.getInstance();
+        }));
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .matchEquals(NotifyWhenDone.getInstance(), n -> getSender().tell(matValue().second(), getSelf()))
+                .build();
+    }
+}

--- a/squbs-unicomplex/src/test/resources/classpaths/JavaKillSwitchMatStream/META-INF/squbs-meta.conf
+++ b/squbs-unicomplex/src/test/resources/classpaths/JavaKillSwitchMatStream/META-INF/squbs-meta.conf
@@ -1,0 +1,8 @@
+cube-name = org.squbs.stream.test.JavaKillSwitchMatStream
+cube-version = "0.0.1"
+squbs-actors = [
+  {
+    class-name = org.squbs.stream.KillSwitchMatStreamJ
+    name = KillSwitchMatStreamJ
+  }
+]

--- a/squbs-unicomplex/src/test/resources/classpaths/KillSwitchMatStream/META-INF/squbs-meta.conf
+++ b/squbs-unicomplex/src/test/resources/classpaths/KillSwitchMatStream/META-INF/squbs-meta.conf
@@ -1,0 +1,8 @@
+cube-name = org.squbs.stream.test.KillSwitchMatStream
+cube-version = "0.0.1"
+squbs-actors = [
+  {
+    class-name = org.squbs.stream.KillSwitchMatStream
+    name = KillSwitchMatStream
+  }
+]

--- a/squbs-unicomplex/src/test/scala/org/squbs/stream/KillSwitchMatStream.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/stream/KillSwitchMatStream.scala
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2017 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.squbs.stream
+
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.stream.{ClosedShape, KillSwitch, KillSwitches}
+import akka.stream.ThrottleMode.Shaping
+import akka.stream.scaladsl.{Flow, GraphDSL, Keep, RunnableGraph, Sink, Source}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object KillSwitchMatStream {
+  val genCount = new AtomicLong(0L)
+}
+
+class KillSwitchMatStream extends PerpetualStream[(KillSwitch, Future[Long])] {
+  import KillSwitchMatStream._
+  import org.squbs.unicomplex.Timeouts._
+
+  override def stopTimeout = awaitMax
+
+  def generator = Iterator.iterate(0){ p => if (p == Int.MaxValue) 0 else p + 1 } map { v =>
+    genCount.incrementAndGet()
+    v
+  }
+
+  val source = Source.fromIterator(generator _)
+
+  val throttle = Flow[Int].throttle(5000, 1 second, 1000, Shaping)
+
+  val counter = Flow[Int].map { _ => 1L }.reduce { _ + _ }.toMat(Sink.head)(Keep.right)
+
+  override def streamGraph = RunnableGraph.fromGraph(GraphDSL.create(KillSwitches.single[Int], counter)((_, _)) {
+    implicit builder =>
+      (kill, sink) =>
+        import GraphDSL.Implicits._
+        source ~> kill ~> throttle ~> sink
+        ClosedShape
+  })
+
+  override def receive = {
+    case NotifyWhenDone =>
+
+      // Send back the future directly here, don't map the future. The map will likely happen after ActorSystem
+      // shutdown so we cannot use context.dispatcher as execution context for the map as it won't be there when
+      // the map is supposed to happen.
+      sender() ! matValue._2
+  }
+}


### PR DESCRIPTION
First materialized value being `KillSwitch` is auto-recognized by `shutdown`.

Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [x] Documentation added/updated.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
