### PR TITLE
#584 Link getting started page to squbs giter8 templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Each of the components have virtually no dependency on each others. They are tru
 
 ## Getting Started
 
-The easiest way to getting started is to create a project from one of the squbs templates. The followings are currently available Activator templates:
+The easiest way to getting started is to create a project from one of the squbs templates. The followings are currently available giter8 templates:
 
-* [squbs-scala-sample](https://www.lightbend.com/activator/template/squbs-scala-sample): Scala sample application
-* [squbs-java-sample](https://www.lightbend.com/activator/template/squbs-java-sample): Java sample application
+* [squbs-scala-seed](https://github.com/paypal/squbs-scala-seed.g8/tree/Release-0.9.X): Scala template
+* [squbs-java-seed](https://github.com/paypal/squbs-java-seed.g8/tree/Release-0.9.X): Java template
 
 Also check out these [slightly more advanced samples](https://github.com/paypal/squbs/tree/master/samples).
 

--- a/docs/httpclient.md
+++ b/docs/httpclient.md
@@ -234,7 +234,7 @@ Please see [squbs pipeline](pipeline.md) to find out how to create a pipeline an
 
 ### Metrics
 
-squbs comes with pre-built [pipeline](#pipeline) elements for metrics collection and squbs activator templates sets those as default.  Accordingly, each squbs http client is enabled to collect [Codahale Metrics](http://metrics.dropwizard.io/3.1.0/getting-started/) out-of-the-box without any code change or configuration.  The following metrics are available on JMX by default:
+squbs comes with pre-built [pipeline](#pipeline) elements for metrics collection and squbs giter8 templates sets those as default.  Accordingly, each squbs http client is enabled to collect [Codahale Metrics](http://metrics.dropwizard.io/3.1.0/getting-started/) out-of-the-box without any code change or configuration.  The following metrics are available on JMX by default:
 
    * Request Timer
    * Request Count Meter


### PR DESCRIPTION
Getting started page should have links to squbs giter8 templates instead of activator templates.
