### PR TITLE
#584 Getting started page should have correct description for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ squbs (pronounced "skewbs") is a software container and a suite of components en
 
 ## Getting Started
 
-The easiest way to getting started is to create a project from one of the squbs templates. The followings are currently available Activator templates:
+The easiest way to getting started is to create a project from one of the squbs templates. The followings are currently available giter8 templates:
 
-* [squbs-scala-seed](https://github.com/paypal/squbs-scala-seed.g8): Scala sample application
-* [squbs-java-seed](https://github.com/paypal/squbs-java-seed.g8): Java sample application
+* [squbs-scala-seed](https://github.com/paypal/squbs-scala-seed.g8): Template for creating sample squbs scala application
+* [squbs-java-seed](https://github.com/paypal/squbs-java-seed.g8): Template for creating sample squbs java application
 
 Also check out these [slightly more advanced samples](https://github.com/paypal/squbs/tree/master/samples).
 

--- a/docs/http-services.md
+++ b/docs/http-services.md
@@ -256,7 +256,7 @@ There are a few rules you have to keep in mind when implementing a `FlowDefiniti
 
 ## Metrics
 
-squbs comes with pre-built [pipeline](#pipeline) elements for metrics collection and squbs activator templates sets those as default.  Accordingly, each squbs http(s) service is enabled to collect [Codahale Metrics](http://metrics.dropwizard.io/3.1.0/getting-started/) out-of-the-box without any code change or configuration.  Please note, squbs metrics collection does NOT require AspectJ or any other runtime code weaving.  The following metrics are available on JMX by default:
+squbs comes with pre-built [pipeline](#pipeline) elements for metrics collection and squbs giter8 templates sets those as default.  Accordingly, each squbs http(s) service is enabled to collect [Codahale Metrics](http://metrics.dropwizard.io/3.1.0/getting-started/) out-of-the-box without any code change or configuration.  Please note, squbs metrics collection does NOT require AspectJ or any other runtime code weaving.  The following metrics are available on JMX by default:
 
    * Request Level Metrics:
       * Request Timer

--- a/docs/httpclient.md
+++ b/docs/httpclient.md
@@ -234,7 +234,7 @@ Please see [squbs pipeline](pipeline.md) to find out how to create a pipeline an
 
 ### Metrics
 
-squbs comes with pre-built [pipeline](#pipeline) elements for metrics collection and squbs activator templates sets those as default.  Accordingly, each squbs http client is enabled to collect [Codahale Metrics](http://metrics.dropwizard.io/3.1.0/getting-started/) out-of-the-box without any code change or configuration.  Please note, squbs metrics collection does NOT require AspectJ or any other runtime code weaving.  The following metrics are available on JMX by default:
+squbs comes with pre-built [pipeline](#pipeline) elements for metrics collection and squbs giter8 templates sets those as default.  Accordingly, each squbs http client is enabled to collect [Codahale Metrics](http://metrics.dropwizard.io/3.1.0/getting-started/) out-of-the-box without any code change or configuration.  Please note, squbs metrics collection does NOT require AspectJ or any other runtime code weaving.  The following metrics are available on JMX by default:
 
    * Request Timer
    * Request Count Meter

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,10 +31,10 @@ Each of the components have virtually no dependency on each others. They are tru
 
 ## Getting Started
 
-The easiest way to getting started is to create a project from one of the squbs templates. The followings are currently available Activator templates:
+The easiest way to getting started is to create a project from one of the squbs templates. The followings are currently available giter8 templates:
 
-* [squbs-scala-sample](https://www.lightbend.com/activator/template/squbs-scala-sample): Scala sample application
-* [squbs-java-sample](https://www.lightbend.com/activator/template/squbs-java-sample): Java sample application
+* [squbs-scala-seed](https://github.com/paypal/squbs-scala-seed.g8): Template for creating sample squbs scala application
+* [squbs-java-seed](https://github.com/paypal/squbs-java-seed.g8): Template for creating sample squbs java application
 
 Also check out these [slightly more advanced samples](https://github.com/paypal/squbs/tree/master/samples).
 


### PR DESCRIPTION
We have changed the templates to giter8 from activator and squbs docs should reflect it as well.
