### PR TITLE
 #549: Adjust CircuitBreaker failurdecider JAPI

### DIFF
--- a/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/japi/CircuitBreakerSettings.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/japi/CircuitBreakerSettings.scala
@@ -17,6 +17,7 @@ package org.squbs.streams.circuitbreaker.japi
 
 import java.util.Optional
 import java.util.function.{Consumer, Function}
+import java.lang.{Boolean => JBoolean}
 
 import org.squbs.streams.UniqueId
 import org.squbs.streams.circuitbreaker.CircuitBreakerState
@@ -34,7 +35,7 @@ case class CircuitBreakerSettings[In, Out, Context] private[japi] (
   cleanUp: Consumer[Out] = new Consumer[Out] {
     override def accept(t: Out): Unit = ()
   },
-  failureDecider: Optional[Function[Try[Out], Boolean]] = Optional.empty[Function[Try[Out], Boolean]],
+  failureDecider: Optional[Function[Try[Out], JBoolean]] = Optional.empty[Function[Try[Out], JBoolean]],
   uniqueIdMapper: Function[Context, Optional[Any]] = new Function[Context, Optional[Any]] {
     override def apply(t: Context): Optional[Any] = Optional.empty()
   }) {
@@ -45,7 +46,7 @@ case class CircuitBreakerSettings[In, Out, Context] private[japi] (
   def withCleanUp(cleanUp: Consumer[Out]): CircuitBreakerSettings[In, Out, Context] =
     copy(cleanUp = cleanUp)
 
-  def withFailureDecider(failureDecider: Function[Try[Out], Boolean]):
+  def withFailureDecider(failureDecider: Function[Try[Out], JBoolean]):
   CircuitBreakerSettings[In, Out, Context] = copy(failureDecider = Optional.of(failureDecider))
 
   def withUniqueIdMapper(uniqueIdMapper: Function[Context, Optional[Any]]):
@@ -58,7 +59,7 @@ case class CircuitBreakerSettings[In, Out, Context] private[japi] (
       circuitBreakerState,
       fallback.asScala.map(f => (in: In) => f(in)),
       (out: Out) => cleanUp.accept(out),
-      failureDecider.asScala.map(f => (out: Try[Out]) => f(out)),
+      failureDecider.asScala.map(f => (out: Try[Out]) => f(out).asInstanceOf[Boolean]),
       UniqueId.javaUniqueIdMapperAsScala(uniqueIdMapper))
 }
 


### PR DESCRIPTION
Change the japi CircuitBreakerSettings for failuredecider to return Java
Boolean.
Also updated JavaTestKit -> TestKit in CircuitBreakerBidiFlowTest


Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [ ] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
