### PR TITLE
#559 Address Retry ordering issues and refactor the logic

### DIFF
--- a/docs/flow-retry.md
+++ b/docs/flow-retry.md
@@ -145,7 +145,7 @@ Any response with failing http status code is also considered a failure:
 
 val failureDecider = (tryResponse: Try[HttpResponse]) => tryResponse.isFailure || tryResponse.get().status().isFailure()
 
-val retryBidi = RetryBidi[Request, Response, MyContext](maxRetries = 3, (context: MyContext) => Some(context.uuid), failureDecider = Option(failureDecider), OverflowStrategy.backpressure())
+val retryBidi = RetryBidi[Request, Response, MyContext](maxRetries = 3, (context: MyContext) => Some(context.uuid), failureDecider = Option(failureDecider))
 
 ```
 
@@ -161,7 +161,7 @@ tryResponse -> tryResponse.isFailure() || tryResponse.get().status().isFailure()
 
 final BidiFlow<Pair<HttpResponse, MyContext>, Pair<HttpResponse, MyContext>, Pair<Try<HttpResponse>, MyContext>,
     Pair<Try<HttpResponse>, MyContext>, NotUsed> retryFlow =
-    RetryBidi.create(3L, Optional.of(failureDecider), OverflowStrategy.backpressure());
+    RetryBidi.create(3L, Optional.of(failureDecider));
 
 ```
 

--- a/squbs-ext/src/main/scala/org/squbs/streams/RetryBidi.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/RetryBidi.scala
@@ -264,7 +264,7 @@ final class RetryBidi[In, Out, Context] private[streams](maxRetries: Int, unique
           else {
             if (pullIn1Condition) pull(in1)
             // If the head is not ready yet, while there is a demand, we should schedule a timer.
-            if (!retryQ.isEmpty && !isTimerActive(timerName)) scheduleOnce(timerName, remainingDelay)
+            if (!noDelay && !retryQ.isEmpty && !isTimerActive(timerName)) scheduleOnce(timerName, remainingDelay)
           }
         }
       }

--- a/squbs-ext/src/test/java/org/squbs/streams/RetryBidiTest.java
+++ b/squbs-ext/src/test/java/org/squbs/streams/RetryBidiTest.java
@@ -21,7 +21,6 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
-import akka.stream.OverflowStrategy;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
@@ -94,7 +93,7 @@ public class RetryBidiTest {
                                 return new Pair<>(failure, elem.second());
                             else
                                 return new Pair<>(Success.apply(elem.first()), elem.second());
-                            });
+                        });
         final BidiFlow<Pair<String, UUID>, Pair<String, UUID>, Pair<Try<String>, UUID>,
                 Pair<Try<String>, UUID>, NotUsed> retry = RetryBidi.create(2);
 
@@ -148,7 +147,7 @@ public class RetryBidiTest {
         Function<MyContext, Optional<Object>> uniqueIdMapper = context -> Optional.of(context.uuid);
         final BidiFlow<Pair<String, MyContext>, Pair<String, MyContext>, Pair<Try<String>, MyContext>,
                 Pair<Try<String>, MyContext>, NotUsed> retryFlow =
-                RetryBidi.create(3, uniqueIdMapper, OverflowStrategy.backpressure());
+                RetryBidi.create(3, uniqueIdMapper);
 
         final CompletionStage<List<Try<String>>> result =
                 Source.from(Arrays.asList("a", "b", "c"))
@@ -172,8 +171,7 @@ public class RetryBidiTest {
                 out -> out.isFailure() || out.equals(Success.apply("a")); // treat "a" as a failure for retry
 
         final BidiFlow<Pair<String, UUID>, Pair<String, UUID>, Pair<Try<String>, UUID>,
-                Pair<Try<String>, UUID>, NotUsed> retry = RetryBidi.create(1,
-                Optional.of(failureDecider), OverflowStrategy.backpressure());
+                Pair<Try<String>, UUID>, NotUsed> retry = RetryBidi.create(1, Optional.of(failureDecider));
 
         Source.from(Arrays.asList("a", "b"))
                 .map(s -> new Pair<>(s, UUID.randomUUID()))
@@ -259,8 +257,7 @@ public class RetryBidiTest {
         final Function<MyContext, Optional<Object>> uniqueIdMapper = context -> Optional.of(context.uuid);
         final BidiFlow<Pair<String, MyContext>, Pair<String, MyContext>, Pair<Try<String>, MyContext>,
                 Pair<Try<String>, MyContext>, NotUsed> retryFlow =
-                RetryBidi.create(3, uniqueIdMapper, Optional.of(failureDecider),
-                        OverflowStrategy.backpressure());
+                RetryBidi.create(3, uniqueIdMapper, Optional.of(failureDecider));
 
         final CompletionStage<List<Try<String>>> result =
                 Source.from(Arrays.asList("a", "b", "c"))
@@ -292,8 +289,7 @@ public class RetryBidiTest {
         final RetrySettings<String, String, MyContext> retrySettings =
                 RetrySettings.<String, String, MyContext>create(3)
                     .withFailureDecider(failureDecider)
-                    .withUniqueIdMapper(uniqueIdMapper)
-                    .withOverflowStrategy(OverflowStrategy.backpressure());
+                    .withUniqueIdMapper(uniqueIdMapper);
 
         final BidiFlow<Pair<String, MyContext>, Pair<String, MyContext>, Pair<Try<String>, MyContext>,
                 Pair<Try<String>, MyContext>, NotUsed> retryFlow =

--- a/squbs-ext/src/test/scala/org/squbs/streams/RetryBidiSpec.scala
+++ b/squbs-ext/src/test/scala/org/squbs/streams/RetryBidiSpec.scala
@@ -21,11 +21,11 @@ import java.util.concurrent.atomic.AtomicLong
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.Attributes.inputBuffer
-import akka.stream.{ActorMaterializer, BufferOverflowException, OverflowStrategy, ThrottleMode}
+import akka.stream.{ActorMaterializer, OverflowStrategy, ThrottleMode}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKit
-import org.scalatest.{AsyncFlatSpecLike, FlatSpecLike, Matchers}
+import org.scalatest.{AsyncFlatSpecLike, Matchers}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -44,10 +44,6 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
   it should "require expbackoff >= 0" in {
     an[IllegalArgumentException] should be thrownBy
       RetryBidi[String, String, NotUsed](1, exponentialBackoffFactor = -0.5)
-  }
-
-  it should "retry settings use backpressure overflow strategy by default" in {
-    assert(RetrySettings(1).overflowStrategy.equals(OverflowStrategy.backpressure))
   }
 
   it should "retry settings failure decider should default to None" in {
@@ -324,88 +320,7 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
       .toMat(TestSink.probe)(Keep.both).run()
 
     source.sendNext("1").sendNext("2").sendNext("3").sendComplete()
-    sink.request(3).expectNext((Success("1"), 1L)).expectNextUnordered((failure, 2L), (failure, 3L))
-    succeed
-  }
-
-  it should "drop head elements and emit them when dropHead buffer mode" in {
-    val bottom = Flow[(String, Long)].delay(10.millis).map {
-      case (_, ctx) => (failure, ctx)
-    }
-    val retry = RetryBidi[String, String, Long](10, overflowStrategy = OverflowStrategy.dropHead)
-      .withAttributes(inputBuffer(initial = 1, max = 3))
-
-    val sink = Source(1 to 5)
-      .map(x => (x.toString, x.toLong))
-      .via(retry.join(bottom))
-      .runWith(TestSink.probe)
-
-    // 1 and 2 element are emitted after being dropped from buffer, 3-5 after exhausting all retries
-    sink
-      .request(5)
-      .expectNoMsg(10.millis)
-      .expectNext((failure, 1L), (failure, 2L))
-      .expectNoMsg(100.millis)
-      .expectNext((failure, 3L), (failure, 4L), (failure, 5L))
-    succeed
-  }
-
-  it should "drop tail elements and emit them when dropTail buffer mode" in {
-    val bottom = Flow[(String, Long)].delay(10.millis).map {
-      case (_, ctx) => (failure, ctx)
-    }
-    val retry = RetryBidi[String, String, Long](10, overflowStrategy = OverflowStrategy.dropTail)
-      .withAttributes(inputBuffer(initial = 1, max = 3))
-
-    val sink = Source(1 to 5)
-      .map(x => (x.toString, x.toLong))
-      .via(retry.join(bottom))
-      .runWith(TestSink.probe)
-
-    // element 3 and 4 are emitted after being dropped from buffer
-    sink.request(5)
-      .expectNoMsg(10.millis)
-      .expectNext((failure, 3L), (failure, 4L))
-      .expectNoMsg(100.millis)
-      .expectNext((failure, 1L), (failure, 2L), (failure, 5L))
-    succeed
-  }
-
-  it should "drop new elements when dropNew buffer mode" in {
-    val bottom = Flow[(String, Long)].delay(10.millis).map {
-      case (_, ctx) => (failure, ctx)
-    }
-    val retry = RetryBidi[String, String, Long](2, overflowStrategy = OverflowStrategy.dropNew)
-      .withAttributes(inputBuffer(initial = 1, max = 3))
-
-    val sink = Source(1 to 5)
-      .map(x => (x.toString, x.toLong))
-      .via(retry.join(bottom))
-      .runWith(TestSink.probe)
-
-    sink.request(5)
-      .expectNext((failure, 1L), (failure, 2L), (failure, 3L))
-      .expectComplete() // element 4 and 5 are dropped on buffer full
-    succeed
-  }
-
-  it should "drop all elements in buffer when dropBuffer mode" in {
-    val bottom = Flow[(String, Long)].delay(10.millis).map {
-      case (_, ctx) => (failure, ctx)
-    }
-    val retry = RetryBidi[String, String, Long](10, overflowStrategy = OverflowStrategy.dropBuffer)
-      .withAttributes(inputBuffer(initial = 1, max = 4))
-
-    val sink = Source(1 to 8)
-      .map(x => (x.toString, x.toLong))
-      .via(retry.join(bottom))
-      .runWith(TestSink.probe)
-
-    sink.request(8) // first 16 elements are dropped and immitted when buffer is full the rest after exhausting retries
-      .expectNoMsg(10.millis)
-      .expectNext((failure, 1L), (failure, 2L), (failure, 3L), (failure, 4L))
-      .expectNoMsg(100.millis)
-      .expectNext((failure, 5L), (failure, 6L), (failure, 7L), (failure, 8L))
+    sink.request(3).expectNext((Success("1"), 1L)).expectNextUnordered((failure, 2L), (failure, 3L)).expectComplete()
     succeed
   }
 
@@ -424,22 +339,6 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
       .expectNoMsg(10.millis)
       .expectNext((failure, 1L))
       .expectNoMsg(10.millis)
-    succeed
-  }
-
-  it should "fail when buffer full on fail mode" in {
-    val bottom = Flow[(String, Long)].delay(10.millis).map {
-      case (_, ctx) => (failure, ctx)
-    }
-    val retry = RetryBidi[String, String, Long](1, overflowStrategy = OverflowStrategy.fail)
-      .withAttributes(inputBuffer(initial = 1, max = 1))
-
-    val sink = Source(1 to 3)
-      .map(x => (x.toString, x.toLong))
-      .via(retry.join(bottom))
-      .runWith(TestSink.probe)
-
-    sink.request(3).expectError(BufferOverflowException("Buffer overflow for Retry stage (max capacity was: 1)!"))
     succeed
   }
 
@@ -470,7 +369,7 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
       .via(retry.join(bottom))
       .runWith(TestSink.probe)
 
-    testSink.request(6)
+    testSink.request(5)
       .expectNextN((Success("1"), 1L) :: (Success("3"), 3L) :: (Success("5"), 5L) :: Nil)
       .expectNoMsg(2 second) // 2 x (1s delay)
       .expectNext((failure, 2L))
@@ -479,7 +378,7 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
     succeed
   }
 
-  it should "retry with delay and backoff should increase retry delay" in {
+  it should "increase retry delay with backoff" in {
     val bottom = Flow[(String, Long)].map {
       case (elem, ctx) => if (ctx % 2 == 0) (failure, ctx) else (Success(elem), ctx)
     }
@@ -489,17 +388,16 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
       .via(retry.join(bottom))
       .runWith(TestSink.probe)
 
-    sink.request(6)
+    sink.request(5)
       .expectNextN((Success("1"), 1L) :: (Success("3"), 3L) :: (Success("5"), 5L) :: Nil)
-      .expectNoMsg(16 seconds) // (1s delay + 4s delay + 9s)
-      .expectNext((failure, 4L)) // TODO: acceptable re-ording of exhausted retries?
+      .expectNoMsg(14 seconds) // (1s delay + 4s delay + 9s)
       .expectNext((failure, 2L))
+      .expectNext((failure, 4L))
       .expectComplete()
     succeed
   }
 
-  //TODO
-  ignore should "retry with maxDelay should backoff until maxDelay" in {
+  it should "backoff until maxDelay" in {
     val bottom = Flow[(String, Long)].map {
       case (elem, ctx) => if (ctx % 2 == 0) (failure, ctx) else (Success(elem), ctx)
     }
@@ -510,7 +408,7 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
       .via(retry.join(bottom))
       .runWith(TestSink.probe)
 
-    sink.request(6)
+    sink.request(5)
       .expectNextN((Success("1"), 1L) :: (Success("3"), 3L) :: (Success("5"), 5L) :: Nil)
       .expectNoMsg(9 seconds) // (1s + 4s + 4s maxDelay)
       .expectNext((failure, 2L))
@@ -519,8 +417,7 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
     succeed
   }
 
-  //TODO
-  ignore should "retry with backoff and a delay using settings" in {
+  it should "retry with backoff and a delay using settings" in {
     val bottom = Flow[(String, Long)].map {
       case (elem, ctx) => if (ctx % 2 == 0) (failure, ctx) else (Success(elem), ctx)
     }
@@ -528,7 +425,6 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
       .withDelay(1 second)
       .withMaxDelay(5 seconds)
       .withExponentialBackoff(2)
-      .withOverflowStrategy(OverflowStrategy.backpressure)
 
     val retry = RetryBidi[String, String, Long](retrySettings)
 
@@ -537,8 +433,8 @@ class RetryBidiSpec extends TestKit(ActorSystem("RetryBidiSpec")) with AsyncFlat
       .via(retry.join(bottom))
       .runWith(TestSink.probe)
 
-    sink.request(6)
-      .expectNextN((Success("1"), 1L) :: (Success("3"), 3L) :: (Success("5"), 5L) :: Nil)
+    sink.request(5)
+      .expectNext((Success("1"), 1L), (Success("3"), 3L), (Success("5"), 5L))
       .expectNoMsg(5 seconds)
       .expectNext((failure, 2L))
       .expectNext((failure, 4L))


### PR DESCRIPTION
Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [x] Documentation added/updated.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).

**Description:**

* Fixed ordering issue for retried elements.
* Fixed not completing the stage until there is further demand from downstream.
* A retried element with a lower retry time should be able to go to the head of the retry queue
* Optimizations on method calls and map accesses.
* Stream should complete when upstream completes. Should not require a new demand from downstream to complete (the tests were requiring an extra demand from sink).
* Dropped Overflow strategy support as anything other than backpressure  does not make sense for Retry.  It is not really a buffer, any element in retryregistry is actually inflight, which we cannot drop.


**Things to do:**

* Add test case for putting an element to the head of the queue when retry time is sooner than head's.
* Go over onDownstreamFinish scenarios.