### PR TITLE
 #451: Add java friendly api for PipelineFlowFactory

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -110,8 +110,8 @@ class DummyBidiFlow extends PipelineFlowFactory {
 
   override def create(context: Context)(implicit system: ActorSystem): PipelineFlow = {
      BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-      val inbound = b.add(Flow[RequestContext].map { rc => rc.addRequestHeader(RawHeader("DummyRequest", "ReqValue")) })
-      val outbound = b.add(Flow[RequestContext].map{ rc => rc.addResponseHeader(RawHeader("DummyResponse", "ResValue"))})
+      val inbound = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("DummyRequest", "ReqValue")) })
+      val outbound = b.add(Flow[RequestContext].map{ rc => rc.withResponseHeader(RawHeader("DummyResponse", "ResValue"))})
       BidiShape.fromFlows(inbound, outbound)
     })
   }
@@ -128,10 +128,10 @@ public class DummyBidiFlow extends AbstractPipelineFlowFactory {
         return BidiFlow.fromGraph(GraphDSL.create(b -> {
             final FlowShape<RequestContext, RequestContext> inbound = b.add(
                     Flow.of(RequestContext.class)
-                            .map(rc -> rc.addRequestHeader(RawHeader.create("DummyRequest", "ReqValue"))));
+                            .map(rc -> rc.withRequestHeader(RawHeader.create("DummyRequest", "ReqValue"))));
             final FlowShape<RequestContext, RequestContext> outbound = b.add(
                     Flow.of(RequestContext.class)
-                            .map(rc -> rc.addResponseHeader(RawHeader.create("DummyResponse", "ResValue"))));
+                            .map(rc -> rc.withResponseHeader(RawHeader.create("DummyResponse", "ResValue"))));
 
             return BidiShape.fromFlows(inbound, outbound);
         }));
@@ -156,10 +156,10 @@ class DummyAbortableBidiFlow extends PipelineFlowFactory {
 
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
       import GraphDSL.Implicits._
-      val inboundA = b.add(Flow[RequestContext].map { rc => rc.addRequestHeader(RawHeader("keyInA", "valInA")) })
-      val inboundC = b.add(Flow[RequestContext].map { rc => rc.addRequestHeader(RawHeader("keyInC", "valInC")) })
-      val outboundA = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyOutA", "valOutA"))})
-      val outboundC = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyOutC", "valOutC"))})
+      val inboundA = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyInA", "valInA")) })
+      val inboundC = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyInC", "valInC")) })
+      val outboundA = b.add(Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyOutA", "valOutA"))})
+      val outboundC = b.add(Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyOutC", "valOutC"))})
 
       val inboundOutboundB = b.add(authorization abortable)
 
@@ -198,16 +198,16 @@ public class DummyAbortableBidiFlow extends japi.PipelineFlowFactory {
         return BidiFlow.fromGraph(GraphDSL.create(b -> {
             final FlowShape<RequestContext, RequestContext> inboundA = b.add(
                 Flow.of(RequestContext.class)
-                    .map(rc -> rc.addRequestHeader(RawHeader.create("keyInA", "valInA"))));
+                    .map(rc -> rc.withRequestHeader(RawHeader.create("keyInA", "valInA"))));
             final FlowShape<RequestContext, RequestContext> inboundC = b.add(
                 Flow.of(RequestContext.class)
-                    .map(rc -> rc.addRequestHeader(RawHeader.create("keyInC", "valInC"))));
+                    .map(rc -> rc.withRequestHeader(RawHeader.create("keyInC", "valInC"))));
             final FlowShape<RequestContext, RequestContext> outboundA = b.add(
                 Flow.of(RequestContext.class)
-                    .map(rc -> rc.addRequestHeader(RawHeader.create("keyOutA", "valOutA"))));
+                    .map(rc -> rc.withRequestHeader(RawHeader.create("keyOutA", "valOutA"))));
             final FlowShape<RequestContext, RequestContext> outboundC = b.add(
                 Flow.of(RequestContext.class)
-                    .map(rc -> rc.addResponseHeader(RawHeader.create("keyOutC", "valOutC"))));
+                    .map(rc -> rc.withResponseHeader(RawHeader.create("keyOutC", "valOutC"))));
 
             final BidiShape<RequestContext, RequestContext> inboundOutboundB =
                 b.add(abortable(authorization));

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -189,7 +189,7 @@ class DummyAbortableBidiFlow extends PipelineFlowFactory {
 ##### Java
 
 ```java
-public class DummyAbortableBidiFlow extends AbstractPipelineFlowFactory {
+public class DummyAbortableBidiFlow extends japi.PipelineFlowFactory {
 
     @Override
     public BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed>
@@ -210,7 +210,7 @@ public class DummyAbortableBidiFlow extends AbstractPipelineFlowFactory {
                     .map(rc -> rc.addResponseHeader(RawHeader.create("keyOutC", "valOutC"))));
 
             final BidiShape<RequestContext, RequestContext> inboundOutboundB =
-                b.add(Pipeline.abortable(authorization));
+                b.add(abortable(authorization));
 
             b.from(inboundA).toInlet(inboundOutboundB.in1());
             b.to(inboundC).fromOutlet(inboundOutboundB.out1());

--- a/squbs-ext/src/main/scala/org/squbs/metrics/MetricsFlow.scala
+++ b/squbs-ext/src/main/scala/org/squbs/metrics/MetricsFlow.scala
@@ -42,7 +42,7 @@ object MetricsFlow {
 
     val inbound = Flow[RequestContext].map { rc =>
       metrics.meter(requestCount).mark()
-      rc.withAttributes(requestTime -> metrics.timer(requestTime).time())
+      rc.withAttribute(requestTime, metrics.timer(requestTime).time())
     }
 
     val outbound = Flow[RequestContext].map { rc =>

--- a/squbs-ext/src/main/scala/org/squbs/metrics/MetricsFlow.scala
+++ b/squbs-ext/src/main/scala/org/squbs/metrics/MetricsFlow.scala
@@ -42,7 +42,7 @@ object MetricsFlow {
 
     val inbound = Flow[RequestContext].map { rc =>
       metrics.meter(requestCount).mark()
-      rc ++ (requestTime -> metrics.timer(requestTime).time())
+      rc.withAttributes(requestTime -> metrics.timer(requestTime).time())
     }
 
     val outbound = Flow[RequestContext].map { rc =>

--- a/squbs-httpclient/src/main/scala/org/squbs/httpclient/ClientFlow.scala
+++ b/squbs-httpclient/src/main/scala/org/squbs/httpclient/ClientFlow.scala
@@ -251,7 +251,7 @@ object ClientFlow {
     PipelineExtension(system).getFlow(pipelineSetting, Context(name, ClientPipeline)) match {
       case Some(pipeline) =>
         val tupleToRequestContext = Flow[(HttpRequest, T)].map { case (request, t) =>
-          RequestContext(request, 0).withAttributes(AkkaHttpClientCustomContext -> t)
+          RequestContext(request, 0).withAttribute(AkkaHttpClientCustomContext, t)
         }
 
         val fromRequestContextToTuple = Flow[RequestContext].map { rc =>
@@ -274,7 +274,7 @@ object ClientFlow {
         })
       case None =>
         val customContextToRequestContext = Flow[(HttpRequest, T)].map { case (request, t) =>
-          (request, RequestContext(request, 0).withAttributes(AkkaHttpClientCustomContext -> t))
+          (request, RequestContext(request, 0).withAttribute(AkkaHttpClientCustomContext, t))
         }
 
         val requestContextToCustomContext =

--- a/squbs-httpclient/src/main/scala/org/squbs/httpclient/ClientFlow.scala
+++ b/squbs-httpclient/src/main/scala/org/squbs/httpclient/ClientFlow.scala
@@ -251,7 +251,7 @@ object ClientFlow {
     PipelineExtension(system).getFlow(pipelineSetting, Context(name, ClientPipeline)) match {
       case Some(pipeline) =>
         val tupleToRequestContext = Flow[(HttpRequest, T)].map { case (request, t) =>
-          RequestContext(request, 0) ++ (AkkaHttpClientCustomContext -> t)
+          RequestContext(request, 0).withAttributes(AkkaHttpClientCustomContext -> t)
         }
 
         val fromRequestContextToTuple = Flow[RequestContext].map { rc =>
@@ -274,7 +274,7 @@ object ClientFlow {
         })
       case None =>
         val customContextToRequestContext = Flow[(HttpRequest, T)].map { case (request, t) =>
-          (request, RequestContext(request, 0) ++ (AkkaHttpClientCustomContext -> t))
+          (request, RequestContext(request, 0).withAttributes(AkkaHttpClientCustomContext -> t))
         }
 
         val requestContextToCustomContext =

--- a/squbs-httpclient/src/test/scala/org/squbs/httpclient/ClientFlowPipelineSpec.scala
+++ b/squbs-httpclient/src/test/scala/org/squbs/httpclient/ClientFlowPipelineSpec.scala
@@ -176,10 +176,10 @@ class DummyFlow extends PipelineFlowFactory {
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
       import GraphDSL.Implicits._
 
-      val stageA = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyA", "valA")) })
-      val stageB = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyB", "valB")) })
+      val stageA = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyA", "valA")) })
+      val stageB = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyB", "valB")) })
       val stageC = b.add(dummyBidi)
-      val stageD = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyD", "valD")) })
+      val stageD = b.add(Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyD", "valD")) })
 
       stageA ~> stageB ~> stageC.in1
       stageD <~           stageC.out2
@@ -188,15 +188,15 @@ class DummyFlow extends PipelineFlowFactory {
     })
   }
 
-  val requestFlow = Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyC", "valC")) }
+  val requestFlow = Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyC", "valC")) }
   val dummyBidi =  BidiFlow.fromFlows(requestFlow, Flow[RequestContext])
 }
 
 class PreFlow extends PipelineFlowFactory {
 
   override def create(context: Context)(implicit system: ActorSystem): PipelineFlow = {
-    val inbound = Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyPreInbound", "valPreInbound")) }
-    val outbound = Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyPreOutbound", "valPreOutbound")) }
+    val inbound = Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyPreInbound", "valPreInbound")) }
+    val outbound = Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyPreOutbound", "valPreOutbound")) }
     BidiFlow.fromFlows(inbound, outbound)
   }
 }
@@ -204,8 +204,8 @@ class PreFlow extends PipelineFlowFactory {
 class PostFlow extends PipelineFlowFactory {
 
   override def create(context: Context)(implicit system: ActorSystem): PipelineFlow = {
-    val inbound = Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyPostInbound", "valPostInbound")) }
-    val outbound = Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyPostOutbound", "valPostOutbound")) }
+    val inbound = Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyPostInbound", "valPostInbound")) }
+    val outbound = Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyPostOutbound", "valPostOutbound")) }
     BidiFlow.fromFlows(inbound, outbound)
   }
 }

--- a/squbs-pipeline/build.sbt
+++ b/squbs-pipeline/build.sbt
@@ -12,7 +12,11 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
   "ch.qos.logback" % "logback-classic" % logbackInTestV % "test"
 )
+enablePlugins(de.johoop.testngplugin.TestNGPlugin)
 
-(testOptions in Test) += Tests.Argument(TestFrameworks.ScalaTest, "-h", "report/squbs-pipeline")
+testOptions in Test ++= Seq(
+  Tests.Argument(TestFrameworks.ScalaTest, "-h", "report/squbs-pipeline"),
+  Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
+)
 
 updateOptions := updateOptions.value.withCachedResolution(true)

--- a/squbs-pipeline/src/main/scala/org/squbs/pipeline/PipelineExtension.scala
+++ b/squbs-pipeline/src/main/scala/org/squbs/pipeline/PipelineExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PayPal
+ * Copyright 2018 PayPal
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,25 +18,46 @@ package org.squbs.pipeline
 
 import akka.NotUsed
 import akka.actor._
-import akka.stream.scaladsl._
+import akka.stream.{javadsl, scaladsl}
 import com.typesafe.config.ConfigObject
 
-import scala.annotation.tailrec
 import scala.util.Try
 
 sealed trait PipelineType
-case object ServerPipeline extends PipelineType
-case object ClientPipeline extends PipelineType
+case object ServerPipeline extends PipelineType {
+  def instance = this
+}
+case object ClientPipeline extends PipelineType {
+}
 
 case class Context(name: String, pipelineType: PipelineType)
 
-trait PipelineFlowFactory {
+sealed trait PipelineFlowFactoryType
+trait PipelineFlowFactory extends PipelineFlowFactoryType {
 
   def create(context: Context)(implicit system: ActorSystem):
-  BidiFlow[RequestContext, RequestContext, RequestContext, RequestContext, NotUsed]
+  scaladsl.BidiFlow[RequestContext, RequestContext, RequestContext, RequestContext, NotUsed]
 }
 
-class PipelineExtensionImpl(flowFactoryMap: Map[String, PipelineFlowFactory],
+/**
+  * Java API
+  */
+object Pipeline {
+  def abortable(flow: javadsl.BidiFlow[RequestContext, RequestContext, RequestContext, RequestContext, NotUsed]):
+  javadsl.BidiFlow[RequestContext, RequestContext, RequestContext, RequestContext, NotUsed] =
+    AbortableBidiFlow(flow.asScala).abortable.asJava
+}
+
+/**
+  * Java API
+  */
+abstract class AbstractPipelineFlowFactory extends PipelineFlowFactoryType {
+
+  def create(context: Context, system: ActorSystem):
+    javadsl.BidiFlow[RequestContext, RequestContext, RequestContext, RequestContext, NotUsed]
+}
+
+class PipelineExtensionImpl(flowFactoryMap: Map[String, PipelineFlowFactoryType],
                             serverDefaultFlows: (Option[String], Option[String]),
                             clientDefaultFlows: (Option[String], Option[String]))
                            (implicit system: ActorSystem) extends Extension {
@@ -46,7 +67,7 @@ class PipelineExtensionImpl(flowFactoryMap: Map[String, PipelineFlowFactory],
     val (appFlow, defaultsOn) = pipelineSetting
 
     val (defaultPreFlow, defaultPostFlow) =
-      if(defaultsOn getOrElse true) {
+      if (defaultsOn getOrElse true) {
         context.pipelineType match {
           case ServerPipeline => serverDefaultFlows
           case ClientPipeline => clientDefaultFlows
@@ -54,28 +75,22 @@ class PipelineExtensionImpl(flowFactoryMap: Map[String, PipelineFlowFactory],
       } else (None, None)
 
     val pipelineFlowNames = (defaultPreFlow :: appFlow :: defaultPostFlow :: Nil).flatten
-
-    if(pipelineFlowNames.isEmpty) None
-    else buildPipeline(pipelineFlowNames, context)
+    buildPipeline(pipelineFlowNames, context)
   }
 
   private def buildPipeline(flowNames: Seq[String], context: Context) = {
 
-    val flows = flowNames.toList collect { case name =>
-      val flowFactory = flowFactoryMap.getOrElse(name, throw new IllegalArgumentException(s"Invalid pipeline name $name"))
-      flowFactory.create(context)
-    }
+    val flows = flowNames map { case name =>
+      val flowFactory = flowFactoryMap
+        .getOrElse(name, throw new IllegalArgumentException(s"Invalid pipeline name $name"))
 
-    @tailrec
-    def connectFlows(currentFlow: PipelineFlow, flowList: List[PipelineFlow]): PipelineFlow = {
-
-      flowList match {
-        case Nil => currentFlow
-        case head :: tail => connectFlows(currentFlow atop head, tail)
+      flowFactory match {
+        case factory: PipelineFlowFactory => factory.create(context)
+        case factory: AbstractPipelineFlowFactory => factory.create(context, system).asScala
+        case factory => throw new IllegalArgumentException(s"Unsupported flow factory type ${factory.getClass.getName}")
       }
     }
-
-    Some(connectFlows(flows.head, flows.tail))
+    flows.reduceLeftOption(_ atop _)
   }
 }
 
@@ -91,11 +106,11 @@ object PipelineExtension extends ExtensionId[PipelineExtensionImpl] with Extensi
         (n, v.toConfig)
     }
 
-    var flowMap = Map.empty[String, PipelineFlowFactory]
+    var flowMap = Map.empty[String, PipelineFlowFactoryType]
     flows foreach { case (name, config) =>
       val factoryClassName = config.getString("factory")
 
-      val flowFactory = Class.forName(factoryClassName).newInstance().asInstanceOf[PipelineFlowFactory]
+      val flowFactory = Class.forName(factoryClassName).newInstance().asInstanceOf[PipelineFlowFactoryType]
 
       flowMap = flowMap + (name -> flowFactory)
     }

--- a/squbs-pipeline/src/main/scala/org/squbs/pipeline/RequestContext.scala
+++ b/squbs-pipeline/src/main/scala/org/squbs/pipeline/RequestContext.scala
@@ -40,15 +40,15 @@ case class RequestContext(request: HttpRequest,
                           response: Option[Try[HttpResponse]] = None,
                           attributes: Map[String, Any] = Map.empty) {
 
-  def withResponse(response: Option[Try[HttpResponse]]): RequestContext = {
-    copy(response = response)
+  def withResponse(response: Try[HttpResponse]): RequestContext = {
+    copy(response = Option(response))
   }
 
   /*
   Java API
    */
-  def withResponse(response: Optional[Try[jmHttpResponse]]): RequestContext = {
-    withResponse(response.asScala.asInstanceOf[Option[Try[HttpResponse]]])
+  def withJavaResponse(response: Try[jmHttpResponse]): RequestContext = {
+    withResponse(response.asInstanceOf[Try[HttpResponse]])
   }
 
   def withAttributes(attributes: (String, Any)*): RequestContext = {

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
@@ -45,21 +45,21 @@ public class AbortableBidiFlowTest {
 
     private static final String cfg =
         "dummyFlow2 {\n" +
-            "  type = squbs.pipelineflow\n" +
-            "  factory = org.squbs.pipeline.DummyFlow2J\n" +
-            "}\n" +
-            "preFlow {\n" +
-            "  type = squbs.pipelineflow\n" +
-            "  factory = org.squbs.pipeline.PreFlowJ\n" +
-            "}\n" +
-            "postFlow {\n" +
-            "  type = squbs.pipelineflow\n" +
-            "  factory = org.squbs.pipeline.PostFlowJ\n" +
-            "}\n" +
-            "squbs.pipeline.server.default {\n" +
-            "  pre-flow = preFlow\n" +
-            "  post-flow = postFlow\n" +
-            "}\n";
+        "  type = squbs.pipelineflow\n" +
+        "  factory = org.squbs.pipeline.DummyFlow2J\n" +
+        "}\n" +
+        "preFlow {\n" +
+        "  type = squbs.pipelineflow\n" +
+        "  factory = org.squbs.pipeline.PreFlowJ\n" +
+        "}\n" +
+        "postFlow {\n" +
+        "  type = squbs.pipelineflow\n" +
+        "  factory = org.squbs.pipeline.PostFlowJ\n" +
+        "}\n" +
+        "squbs.pipeline.server.default {\n" +
+        "  pre-flow = preFlow\n" +
+        "  post-flow = postFlow\n" +
+        "}\n";
 
     private static final ActorSystem system = ActorSystem.create("AbortableBidiFlowTest",
         ConfigFactory.parseString(cfg));
@@ -78,7 +78,7 @@ public class AbortableBidiFlowTest {
     public void testAbortableFlow() throws Exception {
         final BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> pipelineFlow =
             pipeLineExtension.getFlow(new Tuple2<>(Option.apply("dummyFlow2"), Option.apply(true)),
-                new Context("dummy", ServerPipeline.instance())).get().asJava();
+                new Context("dummy", ServerPipeline$.MODULE$)).get().asJava();
 
         Flow<RequestContext, RequestContext, NotUsed> httpFlow = pipelineFlow.join(dummyEndpoint);
         final CompletionStage<RequestContext> result = Source
@@ -123,7 +123,7 @@ public class AbortableBidiFlowTest {
     public void testAbortableFlowWithAbort() throws Exception {
         final BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> pipelineFlow =
             pipeLineExtension.getFlow(new Tuple2<>(Option.apply("dummyFlow2"), Option.apply(true)),
-                new Context("dummy", ServerPipeline.instance())).get().asJava();
+                new Context("dummy", ServerPipeline$.MODULE$)).get().asJava();
 
         Flow<RequestContext, RequestContext, NotUsed> httpFlow = pipelineFlow.join(dummyEndpoint);
         RawHeader abortHeader = RawHeader.create("abort", "dummyValue");

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
@@ -68,11 +68,11 @@ public class AbortableBidiFlowTest {
 
     private final Flow<RequestContext, RequestContext, NotUsed> dummyEndpoint = Flow.<RequestContext>create().map(rc ->
         RequestContext.create(rc.getRequest(), rc.httpPipeliningOrder())
-            .withResponse(Optional.of(Success.apply(HttpResponse.create()
+            .withJavaResponse(Success.apply(HttpResponse.create()
                 .withEntity(StreamSupport.stream(rc.getRequest().getHeaders().spliterator(), false)
                     .sorted(Comparator.comparing(HttpHeader::name))
                     .map(Object::toString)
-                    .collect(Collectors.joining(",")))))));
+                    .collect(Collectors.joining(","))))));
 
     @Test
     public void testAbortableFlow() throws Exception {

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
@@ -68,11 +68,11 @@ public class AbortableBidiFlowTest {
 
     private final Flow<RequestContext, RequestContext, NotUsed> dummyEndpoint = Flow.<RequestContext>create().map(rc ->
         RequestContext.create(rc.getRequest(), rc.httpPipeliningOrder())
-            .withJavaResponse(Success.apply(HttpResponse.create()
-                .withEntity(StreamSupport.stream(rc.getRequest().getHeaders().spliterator(), false)
-                    .sorted(Comparator.comparing(HttpHeader::name))
-                    .map(Object::toString)
-                    .collect(Collectors.joining(","))))));
+            .withResponse(Success.apply(HttpResponse.create()
+                            .withEntity(StreamSupport.stream(rc.getRequest().getHeaders().spliterator(), false)
+                                    .sorted(Comparator.comparing(HttpHeader::name))
+                                    .map(Object::toString)
+                                    .collect(Collectors.joining(","))))));
 
     @Test
     public void testAbortableFlow() throws Exception {

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/AbortableBidiFlowTest.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 2018 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.squbs.pipeline;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.*;
+import akka.util.ByteString;
+import com.typesafe.config.ConfigFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+import scala.Option;
+import scala.Tuple2;
+import scala.util.Success;
+
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.testng.Assert.assertEquals;
+
+public class AbortableBidiFlowTest {
+
+    private static final String cfg =
+        "dummyFlow2 {\n" +
+            "  type = squbs.pipelineflow\n" +
+            "  factory = org.squbs.pipeline.DummyFlow2J\n" +
+            "}\n" +
+            "preFlow {\n" +
+            "  type = squbs.pipelineflow\n" +
+            "  factory = org.squbs.pipeline.PreFlowJ\n" +
+            "}\n" +
+            "postFlow {\n" +
+            "  type = squbs.pipelineflow\n" +
+            "  factory = org.squbs.pipeline.PostFlowJ\n" +
+            "}\n" +
+            "squbs.pipeline.server.default {\n" +
+            "  pre-flow = preFlow\n" +
+            "  post-flow = postFlow\n" +
+            "}\n";
+
+    private static final ActorSystem system = ActorSystem.create("AbortableBidiFlowTest",
+        ConfigFactory.parseString(cfg));
+    private static final Materializer mat = ActorMaterializer.create(system);
+    private static final PipelineExtensionImpl pipeLineExtension = PipelineExtension.get(system);
+
+    private final Flow<RequestContext, RequestContext, NotUsed> dummyEndpoint = Flow.<RequestContext>create().map(rc ->
+        RequestContext.create(rc.getRequest(), rc.httpPipeliningOrder())
+            .withResponse(Optional.of(Success.apply(HttpResponse.create()
+                .withEntity(StreamSupport.stream(rc.getRequest().getHeaders().spliterator(), false)
+                    .sorted(Comparator.comparing(HttpHeader::name))
+                    .map(Object::toString)
+                    .collect(Collectors.joining(",")))))));
+
+    @Test
+    public void testAbortableFlow() throws Exception {
+        final BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> pipelineFlow =
+            pipeLineExtension.getFlow(new Tuple2<>(Option.apply("dummyFlow2"), Option.apply(true)),
+                new Context("dummy", ServerPipeline.instance())).get().asJava();
+
+        Flow<RequestContext, RequestContext, NotUsed> httpFlow = pipelineFlow.join(dummyEndpoint);
+        final CompletionStage<RequestContext> result = Source
+            .single(RequestContext.create(HttpRequest.create(), 0L))
+            .runWith(httpFlow.toMat(Sink.head(), Keep.right()), mat);
+
+        final HttpResponse httpResponse = result.toCompletableFuture()
+            .get(Timeouts.awaitMax().toMillis(), TimeUnit.MILLISECONDS).getResponse().get().get();
+
+        final List<HttpHeader> respHeaders = new ArrayList<>();
+        httpResponse.getHeaders().forEach(respHeaders::add);
+        respHeaders.sort(Comparator.comparing(HttpHeader::name));
+
+        List<RawHeader> expectedHeaders = Arrays.asList(
+            RawHeader.create("keyE", "valE"),
+            RawHeader.create("keyC2", "valC2"),
+            RawHeader.create("keyF", "valF"),
+            RawHeader.create("keyPreOutbound", "valPreOutbound"),
+            RawHeader.create("keyPostOutbound", "valPostOutbound")
+        );
+        expectedHeaders.sort(Comparator.comparing(HttpHeader::name));
+        assertEquals(respHeaders, expectedHeaders);
+
+        final String actualEntity = httpResponse.entity().getDataBytes()
+            .runFold(ByteString.empty(), ByteString::concat, mat).toCompletableFuture().get().utf8String();
+        final RawHeader[] entityList = {
+            RawHeader.create("keyA", "valA"),
+            RawHeader.create("keyB", "valB"),
+            RawHeader.create("keyC1", "valC1"),
+            RawHeader.create("keyD", "valD"),
+            RawHeader.create("keyPreInbound", "valPreInbound"),
+            RawHeader.create("keyPostInbound", "valPostInbound")
+        };
+        String expectedEntity = Arrays.stream(entityList)
+            .sorted(Comparator.comparing(HttpHeader::name))
+            .map(Object::toString)
+            .collect(Collectors.joining(","));
+        assertEquals(actualEntity, expectedEntity);
+    }
+
+    @Test
+    public void testAbortableFlowWithAbort() throws Exception {
+        final BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> pipelineFlow =
+            pipeLineExtension.getFlow(new Tuple2<>(Option.apply("dummyFlow2"), Option.apply(true)),
+                new Context("dummy", ServerPipeline.instance())).get().asJava();
+
+        Flow<RequestContext, RequestContext, NotUsed> httpFlow = pipelineFlow.join(dummyEndpoint);
+        RawHeader abortHeader = RawHeader.create("abort", "dummyValue");
+        final CompletionStage<RequestContext> result = Source
+            .single(RequestContext.create(HttpRequest.create().addHeader(abortHeader), 0L))
+            .runWith(httpFlow.toMat(Sink.head(), Keep.right()), mat);
+
+        final HttpResponse httpResponse = result.toCompletableFuture()
+            .get(Timeouts.awaitMax().toMillis(), TimeUnit.MILLISECONDS).getResponse().get().get();
+
+        final List<HttpHeader> respHeaders = new ArrayList<>();
+        httpResponse.getHeaders().forEach(respHeaders::add);
+        respHeaders.sort(Comparator.comparing(HttpHeader::name));
+
+        List<RawHeader> expectedHeaders = Arrays.asList(
+            RawHeader.create("keyC2", "valC2"),
+            RawHeader.create("keyF", "valF"),
+            RawHeader.create("keyPreOutbound", "valPreOutbound")
+        );
+        expectedHeaders.sort(Comparator.comparing(HttpHeader::name));
+        assertEquals(respHeaders, expectedHeaders);
+
+        final String actualEntity = httpResponse.entity().getDataBytes()
+            .runFold(ByteString.empty(), ByteString::concat, mat).toCompletableFuture().get().utf8String();
+        final RawHeader[] entityList = {
+            RawHeader.create("abort", "dummyValue"),
+            RawHeader.create("keyA", "valA"),
+            RawHeader.create("keyB", "valB"),
+            RawHeader.create("keyC1", "valC1"),
+            RawHeader.create("keyPreInbound", "valPreInbound")
+        };
+        String expectedEntity = Arrays.stream(entityList)
+            .sorted(Comparator.comparing(HttpHeader::name))
+            .map(Object::toString)
+            .collect(Collectors.joining(","));
+        assertEquals(actualEntity, expectedEntity);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        system.terminate();
+    }
+
+}

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlow2J.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlow2J.java
@@ -50,9 +50,9 @@ public class DummyFlow2J implements PipelineFlowFactory {
     final private BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> dummyBidi =
         BidiFlow.fromGraph(GraphDSL.create(b -> {
             final FlowShape<RequestContext, RequestContext> requestFlow = b.add(Flow.of(RequestContext.class)
-                .map(rc -> rc.addRequestHeader(RawHeader.create("keyC1", "valC1"))).via(dummyAborterFlow));
+                .map(rc -> rc.withRequestHeader(RawHeader.create("keyC1", "valC1"))).via(dummyAborterFlow));
             final FlowShape<RequestContext, RequestContext> responseFlow = b.add(Flow.of(RequestContext.class)
-                .map(rc -> rc.addResponseHeader(RawHeader.create("keyC2", "valC2"))));
+                .map(rc -> rc.withResponseHeader(RawHeader.create("keyC2", "valC2"))));
             return BidiShape.fromFlows(requestFlow, responseFlow);
         }));
 
@@ -62,17 +62,17 @@ public class DummyFlow2J implements PipelineFlowFactory {
 
         return BidiFlow.fromGraph(GraphDSL.create(b -> {
             final FlowShape<RequestContext, RequestContext> stageA = b.add(Flow.of(RequestContext.class)
-                .map(rc -> rc.addRequestHeader(RawHeader.create("keyA", "valA"))));
+                .map(rc -> rc.withRequestHeader(RawHeader.create("keyA", "valA"))));
             final FlowShape<RequestContext, RequestContext> stageB = b.add(Flow.of(RequestContext.class)
-                .map(rc -> rc.addRequestHeader(RawHeader.create("keyB", "valB"))));
+                .map(rc -> rc.withRequestHeader(RawHeader.create("keyB", "valB"))));
             final BidiShape<RequestContext, RequestContext, RequestContext, RequestContext> stageC =
                 b.add(abortable(dummyBidi));
             final FlowShape<RequestContext, RequestContext> stageD = b.add(Flow.of(RequestContext.class)
-                .map(rc -> rc.addRequestHeader(RawHeader.create("keyD", "valD"))));
+                .map(rc -> rc.withRequestHeader(RawHeader.create("keyD", "valD"))));
             final FlowShape<RequestContext, RequestContext> stageE = b.add(Flow.of(RequestContext.class)
-                .map(rc -> rc.addResponseHeader(RawHeader.create("keyE", "valE"))));
+                .map(rc -> rc.withResponseHeader(RawHeader.create("keyE", "valE"))));
             final FlowShape<RequestContext, RequestContext> stageF = b.add(Flow.of(RequestContext.class)
-                .map(rc -> rc.addResponseHeader(RawHeader.create("keyF", "valF"))));
+                .map(rc -> rc.withResponseHeader(RawHeader.create("keyF", "valF"))));
 
             b.from(stageA).via(stageB).toInlet(stageC.in1());
             b.to(stageD).fromOutlet(stageC.out1());

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlow2J.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlow2J.java
@@ -26,13 +26,16 @@ import akka.stream.FlowShape;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.GraphDSL;
+import org.squbs.pipeline.Context;
+import org.squbs.pipeline.RequestContext;
+import org.squbs.pipeline.japi.PipelineFlowFactory;
 
 import java.util.Comparator;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 //#create-abortable-pipelineflowfactory-java
-public class DummyFlow2J extends AbstractPipelineFlowFactory {
+public class DummyFlow2J implements PipelineFlowFactory {
 
     final private Flow<RequestContext, RequestContext, NotUsed> dummyAborterFlow = Flow.<RequestContext>create().map(rc ->
         rc.getRequest().getHeader("abort").map(x -> rc.abortWith(
@@ -63,7 +66,7 @@ public class DummyFlow2J extends AbstractPipelineFlowFactory {
             final FlowShape<RequestContext, RequestContext> stageB = b.add(Flow.of(RequestContext.class)
                 .map(rc -> rc.addRequestHeader(RawHeader.create("keyB", "valB"))));
             final BidiShape<RequestContext, RequestContext, RequestContext, RequestContext> stageC =
-                b.add(Pipeline.abortable(dummyBidi));
+                b.add(abortable(dummyBidi));
             final FlowShape<RequestContext, RequestContext> stageD = b.add(Flow.of(RequestContext.class)
                 .map(rc -> rc.addRequestHeader(RawHeader.create("keyD", "valD"))));
             final FlowShape<RequestContext, RequestContext> stageE = b.add(Flow.of(RequestContext.class)

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlow2J.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlow2J.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2018 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.squbs.pipeline;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.stream.BidiShape;
+import akka.stream.FlowShape;
+import akka.stream.javadsl.BidiFlow;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.GraphDSL;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+//#create-abortable-pipelineflowfactory-java
+public class DummyFlow2J extends AbstractPipelineFlowFactory {
+
+    final private Flow<RequestContext, RequestContext, NotUsed> dummyAborterFlow = Flow.<RequestContext>create().map(rc ->
+        rc.getRequest().getHeader("abort").map(x -> rc.abortWith(
+            HttpResponse.create()
+                .withEntity(StreamSupport.stream(rc.getRequest().getHeaders().spliterator(), false)
+                    .sorted(Comparator.comparing(HttpHeader::name))
+                    .map(Object::toString)
+                    .collect(Collectors.joining(",")))))
+            .orElse(rc));
+
+
+    final private BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> dummyBidi =
+        BidiFlow.fromGraph(GraphDSL.create(b -> {
+            final FlowShape<RequestContext, RequestContext> requestFlow = b.add(Flow.of(RequestContext.class)
+                .map(rc -> rc.addRequestHeader(RawHeader.create("keyC1", "valC1"))).via(dummyAborterFlow));
+            final FlowShape<RequestContext, RequestContext> responseFlow = b.add(Flow.of(RequestContext.class)
+                .map(rc -> rc.addResponseHeader(RawHeader.create("keyC2", "valC2"))));
+            return BidiShape.fromFlows(requestFlow, responseFlow);
+        }));
+
+    @Override
+    public BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed>
+    create(Context context, ActorSystem system) {
+
+        return BidiFlow.fromGraph(GraphDSL.create(b -> {
+            final FlowShape<RequestContext, RequestContext> stageA = b.add(Flow.of(RequestContext.class)
+                .map(rc -> rc.addRequestHeader(RawHeader.create("keyA", "valA"))));
+            final FlowShape<RequestContext, RequestContext> stageB = b.add(Flow.of(RequestContext.class)
+                .map(rc -> rc.addRequestHeader(RawHeader.create("keyB", "valB"))));
+            final BidiShape<RequestContext, RequestContext, RequestContext, RequestContext> stageC =
+                b.add(Pipeline.abortable(dummyBidi));
+            final FlowShape<RequestContext, RequestContext> stageD = b.add(Flow.of(RequestContext.class)
+                .map(rc -> rc.addRequestHeader(RawHeader.create("keyD", "valD"))));
+            final FlowShape<RequestContext, RequestContext> stageE = b.add(Flow.of(RequestContext.class)
+                .map(rc -> rc.addResponseHeader(RawHeader.create("keyE", "valE"))));
+            final FlowShape<RequestContext, RequestContext> stageF = b.add(Flow.of(RequestContext.class)
+                .map(rc -> rc.addResponseHeader(RawHeader.create("keyF", "valF"))));
+
+            b.from(stageA).via(stageB).toInlet(stageC.in1());
+            b.to(stageD).fromOutlet(stageC.out1());
+            b.from(stageE).toInlet(stageC.in2());
+            b.to(stageF).fromOutlet(stageC.out2());
+
+            return new BidiShape<>(stageA.in(), stageD.out(), stageE.in(), stageF.out());
+        }));
+    }
+
+}
+//#create-abortable-pipelineflowfactory-java

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlowJ.java
@@ -24,9 +24,12 @@ import akka.stream.FlowShape;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.GraphDSL;
+import org.squbs.pipeline.Context;
+import org.squbs.pipeline.RequestContext;
+import org.squbs.pipeline.japi.PipelineFlowFactory;
 
 //#create-pipelineflowfactory-java
-public class DummyFlowJ extends AbstractPipelineFlowFactory {
+public class DummyFlowJ implements PipelineFlowFactory {
 
     final private BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> dummyBidi =
       BidiFlow.fromGraph(GraphDSL.create(b -> {

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlowJ.java
@@ -34,7 +34,7 @@ public class DummyFlowJ implements PipelineFlowFactory {
     final private BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> dummyBidi =
       BidiFlow.fromGraph(GraphDSL.create(b -> {
           final FlowShape<RequestContext, RequestContext> requestFlow = b.add(Flow.of(RequestContext.class)
-            .map(rc -> rc.addRequestHeader(RawHeader.create("keyC", "valC"))));
+            .map(rc -> rc.withRequestHeader(RawHeader.create("keyC", "valC"))));
           final FlowShape<RequestContext, RequestContext> responseFlow = b.add(Flow.of(RequestContext.class));
           return BidiShape.fromFlows(requestFlow, responseFlow);
       }));
@@ -46,13 +46,13 @@ public class DummyFlowJ implements PipelineFlowFactory {
         return BidiFlow.fromGraph(GraphDSL.create(b -> {
             // each stage enriches RequestContext
             final FlowShape<RequestContext, RequestContext> stageA = b.add(Flow.of(RequestContext.class)
-              .map(rc -> rc.addRequestHeader(RawHeader.create("keyA", "valA"))));
+              .map(rc -> rc.withRequestHeader(RawHeader.create("keyA", "valA"))));
             final FlowShape<RequestContext, RequestContext> stageB = b.add(Flow.of(RequestContext.class)
-              .map(rc -> rc.addRequestHeader(RawHeader.create("keyB", "valB"))));
+              .map(rc -> rc.withRequestHeader(RawHeader.create("keyB", "valB"))));
             final BidiShape<RequestContext, RequestContext, RequestContext, RequestContext> stageC =
               b.add(dummyBidi);
             final FlowShape<RequestContext, RequestContext> stageD = b.add(Flow.of(RequestContext.class)
-              .map(rc -> rc.addResponseHeader(RawHeader.create("keyD", "valD"))));
+              .map(rc -> rc.withResponseHeader(RawHeader.create("keyD", "valD"))));
 
             b.from(stageA).via(stageB).toInlet(stageC.in1());
             b.to(stageD).fromOutlet(stageC.out2());

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/DummyFlowJ.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2018 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.squbs.pipeline;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.stream.BidiShape;
+import akka.stream.FlowShape;
+import akka.stream.javadsl.BidiFlow;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.GraphDSL;
+
+//#create-pipelineflowfactory-java
+public class DummyFlowJ extends AbstractPipelineFlowFactory {
+
+    final private BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> dummyBidi =
+      BidiFlow.fromGraph(GraphDSL.create(b -> {
+          final FlowShape<RequestContext, RequestContext> requestFlow = b.add(Flow.of(RequestContext.class)
+            .map(rc -> rc.addRequestHeader(RawHeader.create("keyC", "valC"))));
+          final FlowShape<RequestContext, RequestContext> responseFlow = b.add(Flow.of(RequestContext.class));
+          return BidiShape.fromFlows(requestFlow, responseFlow);
+      }));
+
+    @Override
+    public BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed>
+    create(Context context, ActorSystem system) {
+
+        return BidiFlow.fromGraph(GraphDSL.create(b -> {
+            // each stage enriches RequestContext
+            final FlowShape<RequestContext, RequestContext> stageA = b.add(Flow.of(RequestContext.class)
+              .map(rc -> rc.addRequestHeader(RawHeader.create("keyA", "valA"))));
+            final FlowShape<RequestContext, RequestContext> stageB = b.add(Flow.of(RequestContext.class)
+              .map(rc -> rc.addRequestHeader(RawHeader.create("keyB", "valB"))));
+            final BidiShape<RequestContext, RequestContext, RequestContext, RequestContext> stageC =
+              b.add(dummyBidi);
+            final FlowShape<RequestContext, RequestContext> stageD = b.add(Flow.of(RequestContext.class)
+              .map(rc -> rc.addResponseHeader(RawHeader.create("keyD", "valD"))));
+
+            b.from(stageA).via(stageB).toInlet(stageC.in1());
+            b.to(stageD).fromOutlet(stageC.out2());
+
+            return new BidiShape<>(stageA.in(), stageC.out1(), stageC.in2(), stageD.out());
+        }));
+    }
+}
+//#create-pipelineflowfactory-java
+
+

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
@@ -80,7 +80,7 @@ public class PipelineExtensionTest {
     public void testFlowWithDefaults() throws Exception {
         final BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> pipelineFlow =
             pipeLineExtension.getFlow(new Tuple2<>(Option.apply("dummyFlow1"), Option.apply(true)),
-                new Context("dummy", ServerPipeline.instance())).get().asJava();
+                new Context("dummy", ServerPipeline$.MODULE$)).get().asJava();
 
         Flow<RequestContext, RequestContext, NotUsed> httpFlow = pipelineFlow.join(dummyEndpoint);
         final CompletionStage<RequestContext> result = Source

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
@@ -34,7 +34,6 @@ import scala.util.Success;
 
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -68,13 +67,13 @@ public class PipelineExtensionTest {
     private static final PipelineExtensionImpl pipeLineExtension = PipelineExtension.get(system);
 
     private final Flow<RequestContext, RequestContext, NotUsed> dummyEndpoint = Flow.<RequestContext>create().map(r ->
-        RequestContext.create(r.getRequest(), r.httpPipeliningOrder()).withResponse(
-            Optional.of(Success.apply(HttpResponse.create()
+        RequestContext.create(r.getRequest(), r.httpPipeliningOrder()).withJavaResponse(
+            Success.apply(HttpResponse.create()
                 .withEntity(StreamSupport.stream(r.getRequest().getHeaders().spliterator(), false)
                     .sorted(Comparator.comparing(HttpHeader::name))
                     .map(Object::toString)
                     .collect(Collectors.joining(",")))
-                .withHeaders(r.getRequest().getHeaders())))));
+                .withHeaders(r.getRequest().getHeaders()))));
 
     @Test
     public void testFlowWithDefaults() throws Exception {

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright 2018 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.squbs.pipeline;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.*;
+import com.typesafe.config.ConfigFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+import scala.Option;
+import scala.Tuple2;
+import scala.util.Success;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.testng.Assert.assertEquals;
+
+public class PipelineExtensionTest {
+
+    private static final String cfg =
+        "dummyFlow1 {\n" +
+            "  type = squbs.pipelineflow\n" +
+            "  factory = org.squbs.pipeline.DummyFlowJ\n" +
+        "}\n" +
+        "preFlow {\n" +
+        "  type = squbs.pipelineflow\n" +
+        "  factory = org.squbs.pipeline.PreFlowJ\n" +
+        "}\n" +
+        "postFlow {\n" +
+        "  type = squbs.pipelineflow\n" +
+        "  factory = org.squbs.pipeline.PostFlowJ\n" +
+        "}\n" +
+        "squbs.pipeline.server.default {\n" +
+        "  pre-flow = preFlow\n" +
+        "  post-flow = postFlow\n" +
+        "}\n";
+
+    private static final ActorSystem system = ActorSystem.create("PipelineExtensionTest",
+        ConfigFactory.parseString(cfg));
+    private static final Materializer mat = ActorMaterializer.create(system);
+
+    private static final PipelineExtensionImpl pipeLineExtension = PipelineExtension.get(system);
+
+    private final Flow<RequestContext, RequestContext, NotUsed> dummyEndpoint = Flow.<RequestContext>create().map(r ->
+        RequestContext.create(r.getRequest(), r.httpPipeliningOrder()).withResponse(
+            Optional.of(Success.apply(HttpResponse.create()
+                .withEntity(StreamSupport.stream(r.getRequest().getHeaders().spliterator(), false)
+                    .sorted(Comparator.comparing(HttpHeader::name))
+                    .map(Object::toString)
+                    .collect(Collectors.joining(",")))
+                .withHeaders(r.getRequest().getHeaders())))));
+
+    @Test
+    public void testFlowWithDefaults() throws Exception {
+        final BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed> pipelineFlow =
+            pipeLineExtension.getFlow(new Tuple2<>(Option.apply("dummyFlow1"), Option.apply(true)),
+                new Context("dummy", ServerPipeline.instance())).get().asJava();
+
+        Flow<RequestContext, RequestContext, NotUsed> httpFlow = pipelineFlow.join(dummyEndpoint);
+        final CompletionStage<RequestContext> result = Source
+            .single(RequestContext.create(HttpRequest.create(), 0))
+            .runWith(httpFlow.toMat(Sink.head(), Keep.right()), mat);
+        final String actualEntity = result.toCompletableFuture().thenCompose(t -> t.getResponse().get().get().entity()
+            .toStrict(Timeouts.awaitMax().toMillis(), mat)).toCompletableFuture().get().getData().utf8String();
+
+        RawHeader[] entityList = {
+            RawHeader.create("keyA", "valA"),
+            RawHeader.create("keyB", "valB"),
+            RawHeader.create("keyC", "valC"),
+            RawHeader.create("keyPreInbound", "valPreInbound"),
+            RawHeader.create("keyPostInbound", "valPostInbound")
+        };
+        String expectedEntity = Arrays.stream(entityList)
+            .sorted(Comparator.comparing(HttpHeader::name))
+            .map(Object::toString)
+            .collect(Collectors.joining(","));
+
+        assertEquals(actualEntity, expectedEntity);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        system.terminate();
+    }
+
+}

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PipelineExtensionTest.java
@@ -67,7 +67,7 @@ public class PipelineExtensionTest {
     private static final PipelineExtensionImpl pipeLineExtension = PipelineExtension.get(system);
 
     private final Flow<RequestContext, RequestContext, NotUsed> dummyEndpoint = Flow.<RequestContext>create().map(r ->
-        RequestContext.create(r.getRequest(), r.httpPipeliningOrder()).withJavaResponse(
+        RequestContext.create(r.getRequest(), r.httpPipeliningOrder()).withResponse(
             Success.apply(HttpResponse.create()
                 .withEntity(StreamSupport.stream(r.getRequest().getHeaders().spliterator(), false)
                     .sorted(Comparator.comparing(HttpHeader::name))

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PostFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PostFlowJ.java
@@ -24,8 +24,11 @@ import akka.stream.FlowShape;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.GraphDSL;
+import org.squbs.pipeline.Context;
+import org.squbs.pipeline.RequestContext;
+import org.squbs.pipeline.japi.PipelineFlowFactory;
 
-public class PostFlowJ extends AbstractPipelineFlowFactory {
+public class PostFlowJ implements PipelineFlowFactory {
     @Override
     public BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed>
     create(Context context, ActorSystem system) {

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PostFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PostFlowJ.java
@@ -24,8 +24,6 @@ import akka.stream.FlowShape;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.GraphDSL;
-import org.squbs.pipeline.Context;
-import org.squbs.pipeline.RequestContext;
 import org.squbs.pipeline.japi.PipelineFlowFactory;
 
 public class PostFlowJ implements PipelineFlowFactory {
@@ -34,9 +32,9 @@ public class PostFlowJ implements PipelineFlowFactory {
     create(Context context, ActorSystem system) {
         return BidiFlow.fromGraph(GraphDSL.create(b -> {
             final FlowShape<RequestContext, RequestContext> inbound = b.add(Flow.of(RequestContext.class)
-              .map(rc -> rc.addRequestHeader(RawHeader.create("keyPostInbound", "valPostInbound"))));
+              .map(rc -> rc.withRequestHeader(RawHeader.create("keyPostInbound", "valPostInbound"))));
             final FlowShape<RequestContext, RequestContext> outbound = b.add(Flow.of(RequestContext.class)
-              .map(rc -> rc.addResponseHeader(RawHeader.create("keyPostOutbound", "valPostOutbound"))));
+              .map(rc -> rc.withResponseHeader(RawHeader.create("keyPostOutbound", "valPostOutbound"))));
             return BidiShape.fromFlows(inbound, outbound);
         }));
     }

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PostFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PostFlowJ.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2018 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.squbs.pipeline;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.stream.BidiShape;
+import akka.stream.FlowShape;
+import akka.stream.javadsl.BidiFlow;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.GraphDSL;
+
+public class PostFlowJ extends AbstractPipelineFlowFactory {
+    @Override
+    public BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed>
+    create(Context context, ActorSystem system) {
+        return BidiFlow.fromGraph(GraphDSL.create(b -> {
+            final FlowShape<RequestContext, RequestContext> inbound = b.add(Flow.of(RequestContext.class)
+              .map(rc -> rc.addRequestHeader(RawHeader.create("keyPostInbound", "valPostInbound"))));
+            final FlowShape<RequestContext, RequestContext> outbound = b.add(Flow.of(RequestContext.class)
+              .map(rc -> rc.addResponseHeader(RawHeader.create("keyPostOutbound", "valPostOutbound"))));
+            return BidiShape.fromFlows(inbound, outbound);
+        }));
+    }
+}
+

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PreFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PreFlowJ.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2018 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.squbs.pipeline;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.stream.BidiShape;
+import akka.stream.FlowShape;
+import akka.stream.javadsl.BidiFlow;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.GraphDSL;
+
+public class PreFlowJ extends AbstractPipelineFlowFactory {
+    @Override
+    public BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed>
+    create(Context context, ActorSystem system) {
+        return BidiFlow.fromGraph(GraphDSL.create(b -> {
+            final FlowShape<RequestContext, RequestContext> inbound = b.add(Flow.of(RequestContext.class)
+              .map(rc -> rc.addRequestHeader(RawHeader.create("keyPreInbound", "valPreInbound"))));
+            final FlowShape<RequestContext, RequestContext> outbound = b.add(Flow.of(RequestContext.class)
+              .map(rc -> rc.addResponseHeader(RawHeader.create("keyPreOutbound", "valPreOutbound"))));
+            return BidiShape.fromFlows(inbound, outbound);
+        }));
+    }
+}

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PreFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PreFlowJ.java
@@ -24,8 +24,6 @@ import akka.stream.FlowShape;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.GraphDSL;
-import org.squbs.pipeline.Context;
-import org.squbs.pipeline.RequestContext;
 import org.squbs.pipeline.japi.PipelineFlowFactory;
 
 public class PreFlowJ implements PipelineFlowFactory {
@@ -34,9 +32,9 @@ public class PreFlowJ implements PipelineFlowFactory {
     create(Context context, ActorSystem system) {
         return BidiFlow.fromGraph(GraphDSL.create(b -> {
             final FlowShape<RequestContext, RequestContext> inbound = b.add(Flow.of(RequestContext.class)
-              .map(rc -> rc.addRequestHeader(RawHeader.create("keyPreInbound", "valPreInbound"))));
+              .map(rc -> rc.withRequestHeader(RawHeader.create("keyPreInbound", "valPreInbound"))));
             final FlowShape<RequestContext, RequestContext> outbound = b.add(Flow.of(RequestContext.class)
-              .map(rc -> rc.addResponseHeader(RawHeader.create("keyPreOutbound", "valPreOutbound"))));
+              .map(rc -> rc.withResponseHeader(RawHeader.create("keyPreOutbound", "valPreOutbound"))));
             return BidiShape.fromFlows(inbound, outbound);
         }));
     }

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/PreFlowJ.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/PreFlowJ.java
@@ -24,8 +24,11 @@ import akka.stream.FlowShape;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.GraphDSL;
+import org.squbs.pipeline.Context;
+import org.squbs.pipeline.RequestContext;
+import org.squbs.pipeline.japi.PipelineFlowFactory;
 
-public class PreFlowJ extends AbstractPipelineFlowFactory {
+public class PreFlowJ implements PipelineFlowFactory {
     @Override
     public BidiFlow<RequestContext, RequestContext, RequestContext, RequestContext, NotUsed>
     create(Context context, ActorSystem system) {

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/RequestContextTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/RequestContextTest.java
@@ -18,7 +18,6 @@ package org.squbs.pipeline;
 
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
-import akka.japi.Pair;
 import org.testng.annotations.Test;
 import scala.Tuple2;
 import scala.util.Success;
@@ -53,9 +52,9 @@ public class RequestContextTest {
 
     @Test
     public void testCreateFromResponse() {
-        Optional<Try<HttpResponse>> respT = Optional.of(Success.apply(HttpResponse.create()));
-        RequestContext rc = RequestContext.create(HttpRequest.create(), 0).withResponse(respT);
-        assertEquals(rc.getResponse(), respT);
+        Try<HttpResponse> respT = Success.apply(HttpResponse.create());
+        RequestContext rc = RequestContext.create(HttpRequest.create(), 0).withJavaResponse(respT);
+        assertEquals(rc.getResponse(), Optional.of(respT));
     }
 
     @Test

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/RequestContextTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/RequestContextTest.java
@@ -31,12 +31,11 @@ public class RequestContextTest {
     @Test
     public void testCreateWithAttributes() {
         List<String> testL = Arrays.asList("1", "2", "3");
-        List<Tuple2<String, Object>> attrs = Arrays.asList(
-            Tuple2.apply("keyA", "strA"),
-            Tuple2.apply("keyB", testL),
-            Tuple2.apply("keyC", "strC"));
 
-        RequestContext rc = RequestContext.create(HttpRequest.create(), 0).withAttributes(attrs);
+        RequestContext rc = RequestContext.create(HttpRequest.create(), 0)
+                .withAttribute("keyA", "strA")
+                .withAttribute("keyB", testL)
+                .withAttribute("keyC", "strC");
         assertEquals(rc.getAttribute("keyA"), Optional.of("strA"));
         assertEquals(rc.getAttribute("keyB"), Optional.of(testL));
         assertEquals(rc.getAttribute("keyC"), Optional.of("strC"));
@@ -53,7 +52,7 @@ public class RequestContextTest {
     @Test
     public void testCreateFromResponse() {
         Try<HttpResponse> respT = Success.apply(HttpResponse.create());
-        RequestContext rc = RequestContext.create(HttpRequest.create(), 0).withJavaResponse(respT);
+        RequestContext rc = RequestContext.create(HttpRequest.create(), 0).withResponse(respT);
         assertEquals(rc.getResponse(), Optional.of(respT));
     }
 

--- a/squbs-pipeline/src/test/java/org/squbs/pipeline/RequestContextTest.java
+++ b/squbs-pipeline/src/test/java/org/squbs/pipeline/RequestContextTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 PayPal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.squbs.pipeline;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.japi.Pair;
+import org.testng.annotations.Test;
+import scala.Tuple2;
+import scala.util.Success;
+import scala.util.Try;
+
+import java.util.*;
+
+import static org.testng.Assert.assertEquals;
+
+public class RequestContextTest {
+    @Test
+    public void testCreateWithAttributes() {
+        List<String> testL = Arrays.asList("1", "2", "3");
+        List<Tuple2<String, Object>> attrs = Arrays.asList(
+            Tuple2.apply("keyA", "strA"),
+            Tuple2.apply("keyB", testL),
+            Tuple2.apply("keyC", "strC"));
+
+        RequestContext rc = RequestContext.create(HttpRequest.create(), 0).withAttributes(attrs);
+        assertEquals(rc.getAttribute("keyA"), Optional.of("strA"));
+        assertEquals(rc.getAttribute("keyB"), Optional.of(testL));
+        assertEquals(rc.getAttribute("keyC"), Optional.of("strC"));
+        assertEquals(rc.getAttribute("keyD"), Optional.empty());
+    }
+
+    @Test
+    public void testCreateFromRequest() {
+        HttpRequest r = HttpRequest.create();
+        RequestContext rc = RequestContext.create(r, 0);
+        assertEquals(rc.getRequest(), r);
+    }
+
+    @Test
+    public void testCreateFromResponse() {
+        Optional<Try<HttpResponse>> respT = Optional.of(Success.apply(HttpResponse.create()));
+        RequestContext rc = RequestContext.create(HttpRequest.create(), 0).withResponse(respT);
+        assertEquals(rc.getResponse(), respT);
+    }
+
+    @Test
+    public void testDefaultEmptyResponse() {
+        RequestContext rc = RequestContext.create(HttpRequest.create(), 0);
+        assertEquals(rc.getResponse(), Optional.empty());
+    }
+
+}

--- a/squbs-pipeline/src/test/resources/testng.yaml
+++ b/squbs-pipeline/src/test/resources/testng.yaml
@@ -1,0 +1,8 @@
+name: squbs-pipelineTests
+
+tests:
+  - name: PipelineTests
+    classes:
+      - org.squbs.pipeline.PipelineExtensionTest
+      - org.squbs.pipeline.AbortableBidiFlowTest
+      - org.squbs.pipeline.RequestContextTest

--- a/squbs-pipeline/src/test/scala/org/squbs/pipeline/AbortableBidiFlowSpec.scala
+++ b/squbs-pipeline/src/test/scala/org/squbs/pipeline/AbortableBidiFlowSpec.scala
@@ -36,7 +36,7 @@ class AbortableBidiFlowSpec extends TestKit(ActorSystem("AbortableBidiFlowSpec",
   implicit val am = ActorMaterializer()
   val pipelineExtension = PipelineExtension(system)
   val dummyEndpoint = Flow[RequestContext].map { rc =>
-    rc.copy(response = Some(Try(HttpResponse(entity = s"${rc.request.headers.sortBy(_.name).mkString(",")}"))))
+    rc.withResponse(Try(HttpResponse(entity = s"${rc.request.headers.sortBy(_.name).mkString(",")}")))
   }
 
   it should "run the entire flow" in {

--- a/squbs-pipeline/src/test/scala/org/squbs/pipeline/AbortableBidiFlowSpec.scala
+++ b/squbs-pipeline/src/test/scala/org/squbs/pipeline/AbortableBidiFlowSpec.scala
@@ -125,12 +125,12 @@ class DummyFlow2 extends PipelineFlowFactory {
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
       import GraphDSL.Implicits._
 
-      val stageA = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyA", "valA")) })
-      val stageB = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyB", "valB")) })
+      val stageA = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyA", "valA")) })
+      val stageB = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyB", "valB")) })
       val stageC = b.add(dummyBidi abortable)
-      val stageD = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyD", "valD")) })
-      val stageE = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyE", "valE")) })
-      val stageF = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyF", "valF")) })
+      val stageD = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyD", "valD")) })
+      val stageE = b.add(Flow[RequestContext].map { rc => rc.withResponseHeaders(RawHeader("keyE", "valE")) })
+      val stageF = b.add(Flow[RequestContext].map { rc => rc.withResponseHeaders(RawHeader("keyF", "valF")) })
 
       stageA ~> stageB ~> stageC.in1
                           stageC.out1 ~> stageD
@@ -149,8 +149,8 @@ class DummyFlow2 extends PipelineFlowFactory {
   }
 
   val dummyBidi = BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-    val requestFlow = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyC1", "valC1")) }.via(dummyAborterFlow) )
-    val responseFlow = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyC2", "valC2")) } )
+    val requestFlow = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyC1", "valC1")) }.via(dummyAborterFlow) )
+    val responseFlow = b.add(Flow[RequestContext].map { rc => rc.withResponseHeaders(RawHeader("keyC2", "valC2")) } )
     BidiShape.fromFlows(requestFlow, responseFlow)
   })
 }

--- a/squbs-pipeline/src/test/scala/org/squbs/pipeline/PipelineExtensionSpec.scala
+++ b/squbs-pipeline/src/test/scala/org/squbs/pipeline/PipelineExtensionSpec.scala
@@ -36,7 +36,7 @@ class PipelineExtensionSpec extends TestKit(ActorSystem("PipelineExtensionSpec",
   implicit val am = ActorMaterializer()
   val pipelineExtension = PipelineExtension(system)
   val dummyEndpoint = Flow[RequestContext].map { r =>
-    r.copy(response = Some(Try(HttpResponse(entity = s"${r.request.headers.sortBy(_.name).mkString(",")}"))))
+    r.withResponse(Try(HttpResponse(entity = s"${r.request.headers.sortBy(_.name).mkString(",")}")))
   }
 
   it should "build the flow with defaults" in {
@@ -148,7 +148,7 @@ class PipelineExtensionSpec3 extends TestKit(ActorSystem("PipelineExtensionSpec3
   implicit val am = ActorMaterializer()
   val pipelineExtension = PipelineExtension(system)
   val dummyEndpoint = Flow[RequestContext].map { r =>
-    r.copy(response = Some(Try(HttpResponse(entity = s"${r.request.headers.sortBy(_.name).mkString(",")}"))))
+    r.withResponse(Try(HttpResponse(entity = s"${r.request.headers.sortBy(_.name).mkString(",")}")))
   }
 
   it should "return None when no custom flow exists and no defaults specified in config" in {

--- a/squbs-pipeline/src/test/scala/org/squbs/pipeline/PipelineExtensionSpec.scala
+++ b/squbs-pipeline/src/test/scala/org/squbs/pipeline/PipelineExtensionSpec.scala
@@ -179,10 +179,10 @@ class DummyFlow1 extends PipelineFlowFactory {
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
       import GraphDSL.Implicits._
 
-      val stageA = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyA", "valA")) })
-      val stageB = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyB", "valB")) })
+      val stageA = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyA", "valA")) })
+      val stageB = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyB", "valB")) })
       val stageC = b.add(dummyBidi)
-      val stageD = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyD", "valD")) })
+      val stageD = b.add(Flow[RequestContext].map { rc => rc.withResponseHeaders(RawHeader("keyD", "valD")) })
 
       stageA ~> stageB ~> stageC.in1
       stageD <~           stageC.out2
@@ -192,7 +192,7 @@ class DummyFlow1 extends PipelineFlowFactory {
   }
 
   val dummyBidi = BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-    val requestFlow = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyC", "valC")) } )
+    val requestFlow = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyC", "valC")) } )
     val responseFlow = b.add(Flow[RequestContext])
     BidiShape.fromFlows(requestFlow, responseFlow)
   })
@@ -203,8 +203,8 @@ class PreFlow extends PipelineFlowFactory {
   override def create(context: Context)(implicit system: ActorSystem): PipelineFlow = {
 
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-      val inbound = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyPreInbound", "valPreInbound")) })
-      val outbound = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyPreOutbound", "valPreOutbound")) })
+      val inbound = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyPreInbound", "valPreInbound")) })
+      val outbound = b.add(Flow[RequestContext].map { rc => rc.withResponseHeaders(RawHeader("keyPreOutbound", "valPreOutbound")) })
       BidiShape.fromFlows(inbound, outbound)
     })
   }
@@ -215,8 +215,8 @@ class PostFlow extends PipelineFlowFactory {
   override def create(context: Context)(implicit system: ActorSystem): PipelineFlow = {
 
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-      val inbound = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyPostInbound", "valPostInbound")) })
-      val outbound = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyPostOutbound", "valPostOutbound")) })
+      val inbound = b.add(Flow[RequestContext].map { rc => rc.withRequestHeaders(RawHeader("keyPostInbound", "valPostInbound")) })
+      val outbound = b.add(Flow[RequestContext].map { rc => rc.withResponseHeaders(RawHeader("keyPostOutbound", "valPostOutbound")) })
       BidiShape.fromFlows(inbound, outbound)
     })
   }

--- a/squbs-pipeline/src/test/scala/org/squbs/pipeline/RequestContextSpec.scala
+++ b/squbs-pipeline/src/test/scala/org/squbs/pipeline/RequestContextSpec.scala
@@ -38,22 +38,22 @@ class RequestContextSpec extends TestKit(ActorSystem("RequestContextSpecSys")) w
 
     rc1.attributes should have size 0
 
-    val rc2 = rc1.withAttributes(("key1" -> "val1"))
+    val rc2 = rc1.withAttribute("key1", "val1")
     rc1.attributes should have size 0 // Immutability
     rc2.attribute("key1") should be(Some("val1"))
 
-    val rc3 = rc2.withAttributes("key2" -> 1).withAttributes("key3"-> new Exception("Bad Val"))
+    val rc3 = rc2.withAttribute("key2", 1).withAttribute("key3", new Exception("Bad Val"))
     rc3.attribute("key2") should be(Some(1))
     rc3.attribute[Exception]("key3").value.getMessage should be("Bad Val")
     rc3.attribute("key1") should be(Some("val1"))
 
     rc3.attributes should have size 3
 
-    val rc4 = rc3.removeAttributes(util.Arrays.asList("key1"))
+    val rc4 = rc3.removeAttribute("key1")
     rc3.attributes should have size 3 // Immutability
     rc4.attributes should have size 2
 
-    val rc5 = rc4.removeAttributes("notexists")
+    val rc5 = rc4.removeAttribute("notexists")
     rc5.attributes should have size 2
     rc5.attribute("key2") should be(Some(1))
     rc5.attribute[Exception]("key3").value.getMessage should be("Bad Val")
@@ -61,8 +61,8 @@ class RequestContextSpec extends TestKit(ActorSystem("RequestContextSpecSys")) w
 
   it should "handle headers correctly" in {
     val rc1 = RequestContext(HttpRequest(), 0)
-    val rc2 = rc1.addRequestHeader(RawHeader("key1", "val1"))
-    val rc3 = rc2.addRequestHeaders(RawHeader("key2", "val2"), RawHeader("key3", "val3"))
+    val rc2 = rc1.withRequestHeader(RawHeader("key1", "val1"))
+    val rc3 = rc2.withRequestHeaders(RawHeader("key2", "val2"), RawHeader("key3", "val3"))
 
     rc3.request.headers should have size 3
     rc3.response should be(None)
@@ -70,9 +70,9 @@ class RequestContextSpec extends TestKit(ActorSystem("RequestContextSpecSys")) w
 
     val rc4 = rc3.copy(response = Some(Try(HttpResponse())))
     rc4.response.value.get.headers should have size 0
-    val rc5 = rc4.addResponseHeader(RawHeader("key4", "val4"))
-    val rc6 = rc5.addResponseHeaders(RawHeader("key5", "val5"), RawHeader("key6", "val6"))
-    val rc7 = rc6.addResponseHeader(RawHeader("key7", "val7"))
+    val rc5 = rc4.withResponseHeader(RawHeader("key4", "val4"))
+    val rc6 = rc5.withResponseHeaders(RawHeader("key5", "val5"), RawHeader("key6", "val6"))
+    val rc7 = rc6.withResponseHeader(RawHeader("key7", "val7"))
     rc7.request.headers should have size 3
     rc7.response.value.get.headers should have size 4
     rc7.response.value.get.headers should contain(RawHeader("key4", "val4"))

--- a/squbs-pipeline/src/test/scala/org/squbs/pipeline/RequestContextSpec.scala
+++ b/squbs-pipeline/src/test/scala/org/squbs/pipeline/RequestContextSpec.scala
@@ -68,7 +68,7 @@ class RequestContextSpec extends TestKit(ActorSystem("RequestContextSpecSys")) w
     rc3.response should be(None)
     rc3.request.headers should contain(RawHeader("key1", "val1"))
 
-    val rc4 = rc3.copy(response = Some(Try(HttpResponse())))
+    val rc4 = rc3.withResponse(Try(HttpResponse()))
     rc4.response.value.get.headers should have size 0
     val rc5 = rc4.withResponseHeader(RawHeader("key4", "val4"))
     val rc6 = rc5.withResponseHeaders(RawHeader("key5", "val5"), RawHeader("key6", "val6"))

--- a/squbs-pipeline/src/test/scala/org/squbs/pipeline/RequestContextSpec.scala
+++ b/squbs-pipeline/src/test/scala/org/squbs/pipeline/RequestContextSpec.scala
@@ -38,11 +38,11 @@ class RequestContextSpec extends TestKit(ActorSystem("RequestContextSpecSys")) w
 
     rc1.attributes should have size 0
 
-    val rc2 = rc1.withAttributes(util.Arrays.asList(("key1" -> "val1")))
+    val rc2 = rc1.withAttributes(("key1" -> "val1"))
     rc1.attributes should have size 0 // Immutability
     rc2.attribute("key1") should be(Some("val1"))
 
-    val rc3 = rc2 ++ ("key2" -> 1) ++ ("key3"-> new Exception("Bad Val"))
+    val rc3 = rc2.withAttributes("key2" -> 1).withAttributes("key3"-> new Exception("Bad Val"))
     rc3.attribute("key2") should be(Some(1))
     rc3.attribute[Exception]("key3").value.getMessage should be("Bad Val")
     rc3.attribute("key1") should be(Some("val1"))
@@ -53,7 +53,7 @@ class RequestContextSpec extends TestKit(ActorSystem("RequestContextSpecSys")) w
     rc3.attributes should have size 3 // Immutability
     rc4.attributes should have size 2
 
-    val rc5 = rc4 -- ("notexists")
+    val rc5 = rc4.removeAttributes("notexists")
     rc5.attributes should have size 2
     rc5.attribute("key2") should be(Some(1))
     rc5.attribute[Exception]("key3").value.getMessage should be("Bad Val")

--- a/squbs-unicomplex/src/main/scala/org/squbs/unicomplex/FlowHandler.scala
+++ b/squbs-unicomplex/src/main/scala/org/squbs/unicomplex/FlowHandler.scala
@@ -119,10 +119,10 @@ class FlowHandler(routes: Seq[(Path, FlowWrapper, PipelineSetting)], localPort: 
       val zipF: (HttpRequest, Long) => RequestContext = localPort map { port =>
         if (port != 0) {
           // Port is configured, we use the configured port.
-          (hr: HttpRequest, po: Long) => RequestContext(hr, po).addRequestHeaders(LocalPortHeader(port))
+          (hr: HttpRequest, po: Long) => RequestContext(hr, po).withRequestHeader(LocalPortHeader(port))
         } else {
           // Else we use the port from the URI.
-          (hr: HttpRequest, po: Long) => RequestContext(hr, po).addRequestHeaders(LocalPortHeader(hr.uri.effectivePort))
+          (hr: HttpRequest, po: Long) => RequestContext(hr, po).withRequestHeader(LocalPortHeader(hr.uri.effectivePort))
         }
       } getOrElse { (hr: HttpRequest, po: Long) => RequestContext(hr, po) }
 

--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/pipeline/PipelineSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/pipeline/PipelineSpec.scala
@@ -213,10 +213,10 @@ class DummyFlow extends PipelineFlowFactory {
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
       import GraphDSL.Implicits._
 
-      val stageA = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyA", "valA")) })
-      val stageB = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyB", "valB")) })
+      val stageA = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyA", "valA")) })
+      val stageB = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyB", "valB")) })
       val stageC = b.add(dummyBidi)
-      val stageD = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyD", "valD")) })
+      val stageD = b.add(Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyD", "valD")) })
 
       stageA ~> stageB ~> stageC.in1
       stageD <~           stageC.out2
@@ -226,7 +226,7 @@ class DummyFlow extends PipelineFlowFactory {
   }
 
   val dummyBidi = BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-    val requestFlow = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyC", "valC")) } )
+    val requestFlow = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyC", "valC")) } )
     val responseFlow = b.add(Flow[RequestContext])
     BidiShape.fromFlows(requestFlow, responseFlow)
   })
@@ -237,8 +237,8 @@ class PreFlow extends PipelineFlowFactory {
   override def create(context: Context)(implicit system: ActorSystem): PipelineFlow = {
 
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-      val inbound = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyPreInbound", "valPreInbound")) })
-      val outbound = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyPreOutbound", "valPreOutbound")) })
+      val inbound = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyPreInbound", "valPreInbound")) })
+      val outbound = b.add(Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyPreOutbound", "valPreOutbound")) })
       BidiShape.fromFlows(inbound, outbound)
     })
   }
@@ -249,8 +249,8 @@ class PostFlow extends PipelineFlowFactory {
   override def create(context: Context)(implicit system: ActorSystem): PipelineFlow = {
 
     BidiFlow.fromGraph(GraphDSL.create() { implicit b =>
-      val inbound = b.add(Flow[RequestContext].map { rc => rc.addRequestHeaders(RawHeader("keyPostInbound", "valPostInbound")) })
-      val outbound = b.add(Flow[RequestContext].map { rc => rc.addResponseHeaders(RawHeader("keyPostOutbound", "valPostOutbound")) })
+      val inbound = b.add(Flow[RequestContext].map { rc => rc.withRequestHeader(RawHeader("keyPostInbound", "valPostInbound")) })
+      val outbound = b.add(Flow[RequestContext].map { rc => rc.withResponseHeader(RawHeader("keyPostOutbound", "valPostOutbound")) })
       BidiShape.fromFlows(inbound, outbound)
     })
   }


### PR DESCRIPTION
Add Java friendly PipelineFlowFactory API.
Add additional javadsl HttpRequest/Response APIs into RequestContext


Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [x] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
