### PR TITLE
Bump Chronicle Queue and Akka-HTTP version

### DIFF
--- a/docs/persistent-buffer.md
+++ b/docs/persistent-buffer.md
@@ -8,7 +8,7 @@ The following dependencies are required for Persistent Buffer to work:
 
 ```scala
 "org.squbs" %% "squbs-pattern" % squbsVersion,
-"net.openhft" % "chronicle-queue" % "4.16.3"
+"net.openhft" % "chronicle-queue" % "4.16.5"
 ```
 
 ## Examples

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -16,7 +16,7 @@
 
 object Versions {
   val akkaV = "2.5.13"
-  val akkaHttpV = "10.1.2"
+  val akkaHttpV = "10.1.3"
   val scalatestV = "3.0.5"
   val scalaLoggingV = "3.9.0"
   val jacksonV = "2.9.5"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -27,7 +27,7 @@ object Versions {
   val junitV = "4.12"
   val testngV = "6.14.3"
   val accordV = "0.7.2"
-  val chronicleQueueV = "4.16.4"
+  val chronicleQueueV = "4.16.5"
   val logbackInTestV = "1.2.3"
   val curatorV = "4.0.1"
 }

--- a/squbs-pattern/src/main/scala/org/squbs/pattern/stream/PersistentQueue.scala
+++ b/squbs-pattern/src/main/scala/org/squbs/pattern/stream/PersistentQueue.scala
@@ -79,7 +79,7 @@ class PersistentQueue[T](config: QueueConfig, onCommitCallback: Int => Unit = _ 
 
   // `fileIdParser` will parse a given filename to its long value.
   // The value is based on epoch time and grows incrementally.
-  // https://github.com/OpenHFT/Chronicle-Queue/blob/chronicle-queue-4.16.4/src/main/java/net/openhft/chronicle/queue/RollCycles.java#L85
+  // https://github.com/OpenHFT/Chronicle-Queue/blob/chronicle-queue-4.16.5/src/main/java/net/openhft/chronicle/queue/RollCycles.java#L85
   private[stream] val fileIdParser = new RollingResourcesCache(queue.rollCycle(), queue.epoch(),
     (name: String) => new File(builder.path(), name + SUFFIX),
     (file: File) => file.getName.stripSuffix(SUFFIX)


### PR DESCRIPTION
There was [a memory leak at Akka-HTTP 10.1.2](https://github.com/akka/akka-http/issues/2067). These two commits were from https://github.com/paypal/squbs/pull/667, I didn't push yet.

- [ ] Title includes issue id.
- [x] Description of the change added.
- [ ] Commits are squashed.
- [ ] Tests added.
- [x] Documentation added/updated.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
