### PR TITLE
 #661 PerpetualStreamMatValue.matValue should support PerpetualStreams

### DIFF
--- a/squbs-unicomplex/src/main/scala/org/squbs/stream/PerpetualStream.scala
+++ b/squbs-unicomplex/src/main/scala/org/squbs/stream/PerpetualStream.scala
@@ -121,7 +121,7 @@ trait PerpetualStreamMatValue[T] {
             s"Materialized value mismatch. First element should be a Sink. Found ${other.getClass.getName}.")
         }
       case other =>
-        throw new ClassCastException(s"Materialized value mismatch. Should be a Sink. Found ${other.getClass.getName}.")
+        throw new ClassCastException(s"Materialized value mismatch. Should be a Sink or a Product with a Sink as its first element. Found ${other.getClass.getName}.")
     }
   }
 }

--- a/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamMatValueSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamMatValueSpec.scala
@@ -1,0 +1,219 @@
+/*
+ *  Copyright 2019 PayPal
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.squbs.stream
+
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+
+import akka.NotUsed
+import akka.actor.{Actor, ActorRef, ActorRefFactory, ActorSystem, Props}
+import akka.pattern._
+import akka.stream.{ActorMaterializer, ClosedShape}
+import akka.stream.scaladsl.{Flow, GraphDSL, MergeHub, RunnableGraph, Sink, Source}
+import akka.util.Timeout
+import org.scalatest.{FunSpec, Inside, Matchers}
+import org.squbs.stream.PerpetualStreamMatValueSpecHelper.PerpStreamActors
+import org.squbs.unicomplex._
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success, Try}
+
+class PerpetualStreamMatValueSpec
+extends FunSpec
+with Matchers
+with Inside {
+
+  import PerpStreamActors._
+  import PerpetualStreamMatValueSpecHelper._
+
+  describe("PerpetualStreamMatValue matValue") {
+    describe("Successful cases") {
+
+      List(
+        classOf[SinkMaterializingStream],
+        classOf[GoodProductSinkMaterializingStream]
+      ).foreach { clz =>
+        val to = FiniteDuration(1, TimeUnit.SECONDS)
+        useSystem(classOf[PerpStreamActors.SinkMaterializingStream]) {
+          case Success(actor) =>
+            implicit val timeout = Timeout(to)
+            val queue = Await.result((actor ? Queue).mapTo[LinkedBlockingQueue[Long]], to)
+            queue.poll(1, TimeUnit.SECONDS) should be(PerpetualStreamMatValueSpecHelper.payload)
+          case _ => fail("Expected a success")
+        }
+      }
+    }
+
+    describe("Error cases that throw ClassCastException") {
+
+      describe("Cases where we examine the 'first' element, and it is NOT a sink") {
+        List(
+          ("Products"      , classOf[BadProductSinkMaterializingStream]),
+          ("akka.japi.Pair", classOf[BadJapiPairSinkMaterializingStream]),
+          ("java.util.List", classOf[BadJavaListSinkMaterializingStream])
+        ).foreach { case (testName, clz) =>
+
+          it (testName) {
+            useSystem(clz) {
+              case Failure(e) =>
+                e shouldBe a[ClassCastException]
+                e.getMessage should be(
+                  s"Materialized value mismatch. First element should be a Sink. Found ${classOf[Integer].getName}."
+                )
+              case _ => fail("Expected a failure")
+            }
+          }
+        }
+      }
+
+      it("Empty java.util.List") {
+        useSystem(classOf[EmptyJavaListSinkMaterializingStream]) {
+          case Failure(e) =>
+            e shouldBe a[ClassCastException]
+            e.getMessage should be(
+              s"Materialized value mismatch. First element should be a Sink. Found an empty java.util.List."
+            )
+          case _ => fail("Expected a failure")
+        }
+      }
+
+      it("All other cases") {
+        useSystem(classOf[IntProducingStream]) {
+          case Failure(e) =>
+            e shouldBe a[ClassCastException]
+            e.getMessage should be(
+              "Materialized value mismatch. Should be a Sink or a Product/akka.japi.Pair/java.util.List " +
+                s"with a Sink as its first element. Found ${classOf[Integer].getName}."
+            )
+          case _ => fail("Expected a failure")
+        }
+      }
+    }
+  }
+}
+
+object PerpetualStreamMatValueSpecHelper {
+
+  import scala.concurrent.duration._
+  val payload = 1L
+  case object Queue
+  implicit val timeout = Timeout(1.second)
+
+  def useSystem[PC <: PerpStream[_]](perpStream: Class[PC])(fn: Try[ActorRef] => Unit): Unit = {
+    implicit val actorSystem = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    // TODO Is it ok to violate actor creation guidelines here?
+    val perpRef = actorSystem.actorOf(Props(perpStream), "act1")
+    val someRef = actorSystem.actorOf(Props(new SomeActor(perpRef)), "act2")
+
+    Await.result(someRef ? payload, 1.second) match {
+      case Success(_) => fn(Success(perpRef))
+      case Failure(e) => fn(Failure(e))
+    }
+    actorSystem.terminate()
+  }
+
+  trait PerpStream[T] extends PerpetualStream[T] {
+    val batchQueue = new LinkedBlockingQueue[Long]()
+    // https://stackoverflow.com/a/18469420
+    override def receive= ({
+      case Queue => sender() ! batchQueue
+    }: Receive) orElse super.receive
+
+    def addToBatch: Flow[Long, Long, NotUsed] = Flow[Long].map { l => batchQueue.add(l); l }
+  }
+
+  object PerpStreamActors {
+    // TODO Can I not put these within the test:(:(
+    // Seems like I can't due to some Akka actor construction rule.
+
+    class SinkMaterializingStream extends PerpStream[Sink[Long, NotUsed]] {
+      self ! Active
+      override def streamGraph =
+        MergeHub.source[Long].via(addToBatch).to(Sink.ignore)
+    }
+
+    /**
+      * This has Sink[T, NotUsed] as the materialized value's first element.
+      */
+    class GoodProductSinkMaterializingStream extends PerpStream[(Sink[Long, NotUsed], Future[akka.Done])] {
+      self ! Active
+      override def streamGraph = {
+        RunnableGraph.fromGraph(GraphDSL.create(MergeHub.source[Long], Sink.ignore)((_, _)) { implicit builder =>
+          (mergeHubSource, sink) =>
+            import GraphDSL.Implicits._
+            mergeHubSource ~> addToBatch ~> sink
+            ClosedShape
+        })
+      }
+    }
+
+    /**
+      * This materializes a product that does NOT have Sink[T, NotUsed] as its first element.
+      */
+    class BadProductSinkMaterializingStream extends PerpStream[(Int, Any)] {
+      self ! Active
+      override def streamGraph = Source.single(1).toMat(Sink.ignore)((_, _) => (1, 2))
+    }
+
+    /**
+      * This materializes an akka.japi.Pair that does NOT have Sink[T, NotUsed] as its first element.
+      */
+    class BadJapiPairSinkMaterializingStream extends PerpStream[akka.japi.Pair[Int, Any]] {
+      self ! Active
+      override def streamGraph =
+        Source.single(1).toMat(Sink.ignore)((_, _) => akka.japi.Pair.apply(1, 2))
+    }
+
+    /**
+      * This materializes a java.util.List that does NOT have Sink[T, NotUsed] as its first element.
+      */
+    class BadJavaListSinkMaterializingStream extends PerpStream[java.util.List[Int]] {
+      self ! Active
+      override def streamGraph =
+        Source.single(1).toMat(Sink.ignore)((_, _) => java.util.Arrays.asList(1, 2, 3))
+    }
+
+    /**
+      * This materializes an empty java.util.List.
+      */
+    class EmptyJavaListSinkMaterializingStream extends PerpStream[java.util.List[_]] {
+      self ! Active
+      override def streamGraph =
+        Source.single(1).toMat(Sink.ignore)((_, _) => java.util.Collections.emptyList())
+    }
+
+    /**
+      * This materializes an Int (neither a Sink[T, NotUsed] or a product).
+      */
+    class IntProducingStream extends PerpStream[Int] {
+      self ! Active
+      override def streamGraph = Source.single(1).toMat(Sink.ignore)((_, _) => 6)
+    }
+  }
+
+  class SomeActor(perpStream: ActorRef) extends Actor with PerpetualStreamMatValue[Long] {
+    implicit val mat = ActorMaterializer()
+
+    override def actorLookup(name: String)(implicit refFactory: ActorRefFactory, timeout: Timeout) =
+      perpStream
+
+    override def receive: Receive = {
+      case l: Long => sender() ! Try { Source.single(l).to(matValue("any-name-works-see-impl")).run() }
+    }
+  }
+}

--- a/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamMatValueSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamMatValueSpec.scala
@@ -23,17 +23,14 @@ import akka.pattern._
 import akka.stream.{ActorMaterializer, ClosedShape}
 import akka.stream.scaladsl.{Flow, GraphDSL, Keep, MergeHub, RunnableGraph, Sink, Source}
 import akka.util.Timeout
-import org.scalatest.{FunSpec, Inside, Matchers}
+import org.scalatest.{FunSpec, Matchers}
 import org.squbs.stream.PerpetualStreamMatValueSpecHelper.PerpStreamActors
 import org.squbs.unicomplex._
 
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
-class PerpetualStreamMatValueSpec
-extends FunSpec
-with Matchers
-with Inside {
+class PerpetualStreamMatValueSpec extends FunSpec with Matchers {
 
   import PerpStreamActors._
   import PerpetualStreamMatValueSpecHelper._

--- a/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamSpec.scala
@@ -15,39 +15,52 @@
  */
 package org.squbs.stream
 
-import akka.actor.ActorSystem
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+
+import akka.NotUsed
+import akka.actor.{Actor, ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.pattern._
+import akka.stream.{ActorMaterializer, ClosedShape}
+import akka.stream.scaladsl.{Flow, GraphDSL, MergeHub, RunnableGraph, Sink, Source}
+import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.OptionValues._
 import org.scalatest.{FlatSpec, Matchers}
 import org.squbs.lifecycle.GracefulStop
 import org.squbs.unicomplex._
 
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success, Try}
 
 class PerpetualStreamSpec extends FlatSpec with Matchers {
 
-  val dummyJarsDir = getClass.getClassLoader.getResource("classpaths").getPath
+  private val dummyJarsDir = getClass.getClassLoader.getResource("classpaths").getPath
 
-  it should "throw an IllegalStateException when accessing matValue before stream starts" in {
-
-    val classPaths = Array("IllegalStateStream") map (dummyJarsDir + "/" + _)
-
+  private def startUnicomplex(
+    systemName: String
+  ): UnicomplexBoot = {
+    val classPaths: Set[String] = Set(systemName).map(dummyJarsDir + "/" + _)
     val config = ConfigFactory.parseString(
       s"""
          |squbs {
-         |  actorsystem-name = IllegalStateStream
+         |  actorsystem-name = $systemName
          |  ${JMX.prefixConfig} = true
          |}
       """.stripMargin
     )
 
-    val boot = UnicomplexBoot(config)
+    UnicomplexBoot(config)
       .createUsing {
         (name, config) => ActorSystem(name, config)
       }
-      .scanComponents(classPaths)
+      .scanComponents(classPaths.toSeq)
       .start()
+  }
+
+  it should "throw an IllegalStateException when accessing matValue before stream starts" in {
+
+    val boot = startUnicomplex("IllegalStateStream")
 
     import Timeouts._
 
@@ -63,23 +76,7 @@ class PerpetualStreamSpec extends FlatSpec with Matchers {
   }
 
   it should "recover from upstream failure" in {
-    val classPaths = Array("ThrowExceptionStream") map (dummyJarsDir + "/" + _)
-
-    val config = ConfigFactory.parseString(
-      s"""
-         |squbs {
-         |  actorsystem-name = ThrowExceptionStream
-         |  ${JMX.prefixConfig} = true
-         |}
-      """.stripMargin
-    )
-
-    val boot = UnicomplexBoot(config)
-      .createUsing {
-        (name, config) => ActorSystem(name, config)
-      }
-      .scanComponents(classPaths)
-      .start()
+    val boot = startUnicomplex("ThrowExceptionStream")
 
     import ThrowExceptionStream._
     import Timeouts._
@@ -94,23 +91,7 @@ class PerpetualStreamSpec extends FlatSpec with Matchers {
   }
 
   it should "properly drain the stream on shutdown" in {
-    val classPaths = Array("ProperShutdownStream") map (dummyJarsDir + "/" + _)
-
-    val config = ConfigFactory.parseString(
-      s"""
-         |squbs {
-         |  actorsystem-name = ProperShutdownStream
-         |  ${JMX.prefixConfig} = true
-         |}
-      """.stripMargin
-    )
-
-    val boot = UnicomplexBoot(config)
-      .createUsing {
-        (name, config) => ActorSystem(name, config)
-      }
-      .scanComponents(classPaths)
-      .start()
+    val boot = startUnicomplex("ProperShutdownStream")
 
     import ProperShutdownStream._
     import Timeouts._
@@ -129,23 +110,7 @@ class PerpetualStreamSpec extends FlatSpec with Matchers {
   }
 
   it should "properly drain the stream with KillSwitch shutdown" in {
-    val classPaths = Array("KillSwitchStream") map (dummyJarsDir + "/" + _)
-
-    val config = ConfigFactory.parseString(
-      s"""
-         |squbs {
-         |  actorsystem-name = KillSwitchStream
-         |  ${JMX.prefixConfig} = true
-         |}
-      """.stripMargin
-    )
-
-    val boot = UnicomplexBoot(config)
-      .createUsing {
-        (name, config) => ActorSystem(name, config)
-      }
-      .scanComponents(classPaths)
-      .start()
+    val boot = startUnicomplex("KillSwitchStream")
 
     import KillSwitchStream._
     import Timeouts._
@@ -164,23 +129,7 @@ class PerpetualStreamSpec extends FlatSpec with Matchers {
   }
 
   it should "properly drain the stream materializing to KillSwitch at shutdown" in {
-    val classPaths = Array("KillSwitchMatStream") map (dummyJarsDir + "/" + _)
-
-    val config = ConfigFactory.parseString(
-      s"""
-         |squbs {
-         |  actorsystem-name = KillSwitchMatStream
-         |  ${JMX.prefixConfig} = true
-         |}
-      """.stripMargin
-    )
-
-    val boot = UnicomplexBoot(config)
-      .createUsing {
-        (name, config) => ActorSystem(name, config)
-      }
-      .scanComponents(classPaths)
-      .start()
+    val boot = startUnicomplex("KillSwitchMatStream")
 
     import KillSwitchMatStream._
     import Timeouts._
@@ -199,23 +148,7 @@ class PerpetualStreamSpec extends FlatSpec with Matchers {
   }
 
   it should "properly drain the stream with KillSwitch shutdown having other child actor" in {
-    val classPaths = Array("KillSwitchWithChildActorStream") map (dummyJarsDir + "/" + _)
-
-    val config = ConfigFactory.parseString(
-      s"""
-         |squbs {
-         |  actorsystem-name = KillSwitchWithChildActorStream
-         |  ${JMX.prefixConfig} = true
-         |}
-      """.stripMargin
-    )
-
-    val boot = UnicomplexBoot(config)
-      .createUsing {
-        (name, config) => ActorSystem(name, config)
-      }
-      .scanComponents(classPaths)
-      .start()
+    val boot = startUnicomplex("KillSwitchWithChildActorStream")
 
     import KillSwitchWithChildActorStream._
     import Timeouts._
@@ -232,5 +165,135 @@ class PerpetualStreamSpec extends FlatSpec with Matchers {
     val count = Await.result(countF, awaitMax)
     println(s"Counts -> src: ${genCount.get} dest: $count")
     count shouldBe genCount.get
+  }
+
+  "PerpetualStreamMatValue's matValue(String)" should "return a Sink[T, NotUsed] " +
+    "when the referenced perpetualstream's mat value is a Sink[T, NotUsed]" in {
+    import PerpetualStreamMatValueSpecHelper._
+    val to = FiniteDuration(1, TimeUnit.SECONDS)
+    useSystem(classOf[PerpStreamActors.SinkMaterializingStream]) { case Right(actor) =>
+      implicit val timeout = Timeout(to)
+      val queue = Await.result((actor ? Queue).mapTo[LinkedBlockingQueue[Long]], to)
+      queue.poll(1, TimeUnit.SECONDS) should be(PerpetualStreamMatValueSpecHelper.payload)
+    }
+  }
+
+  it should "return a Sink[T, NotUsed] when the referenced perpetualstream's " +
+    "mat value is a product where the first 'element' is Sink[T, NotUsed]" in {
+    import PerpetualStreamMatValueSpecHelper._
+    val to = FiniteDuration(1, TimeUnit.SECONDS)
+    useSystem(classOf[PerpStreamActors.GoodProductSinkMaterializingStream]) { case Right(actor) =>
+      implicit val timeout = Timeout(to)
+      val queue = Await.result((actor ? Queue).mapTo[LinkedBlockingQueue[Long]], to)
+      queue.poll(1, TimeUnit.SECONDS) should be(PerpetualStreamMatValueSpecHelper.payload)
+    }
+  }
+
+  it should "throw a ClassCastException when the referenced perpetualstream's " +
+    "mat value is a product and the first 'element' is NOT a Sink[T, NotUsed]" in {
+    import PerpetualStreamMatValueSpecHelper._
+    useSystem(classOf[PerpStreamActors.BadProductSinkMaterializingStream]) { case Left(e) =>
+      e shouldBe a[ClassCastException]
+      e.getMessage should be(
+        s"Materialized value mismatch. First element should be a Sink. Found ${classOf[Integer].getName}."
+      )
+    }
+  }
+
+  it should "throw a ClassCastException when the referenced perpetualstream's " +
+    "mat value is anything else" in {
+    import PerpetualStreamMatValueSpecHelper._
+    useSystem(classOf[PerpStreamActors.IntProducingStream]) { case Left(e) =>
+      e shouldBe a[ClassCastException]
+      e.getMessage should be(
+        s"Materialized value mismatch. Should be a Sink. Found ${classOf[Integer].getName}."
+      )
+    }
+  }
+}
+
+object PerpetualStreamMatValueSpecHelper {
+
+  import scala.concurrent.duration._
+  val payload = 1L
+  case object Queue
+  implicit val timeout = Timeout(1.second)
+
+  def useSystem[PC <: PerpStream[_]](perpStream: Class[PC])(fn: Either[Throwable, ActorRef] => Unit): Unit = {
+    implicit val actorSystem = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    // TODO Is it ok to violate actor creation guidelines here?
+    val perpRef = actorSystem.actorOf(Props(perpStream), "act1")
+    val someRef = actorSystem.actorOf(Props(new SomeActor(perpRef)), "act2")
+
+    Await.result(someRef ? payload, 1.second) match {
+      case Success(_) => fn(Right(perpRef))
+      case Failure(e) => fn(Left(e))
+    }
+    actorSystem.terminate()
+  }
+
+  trait PerpStream[T] extends PerpetualStream[T] {
+    val batchQueue = new LinkedBlockingQueue[Long]()
+    // https://stackoverflow.com/a/18469420
+    override def receive= ({
+      case Queue => sender() ! batchQueue
+    }: Receive) orElse super.receive
+
+    def addToBatch: Flow[Long, Long, NotUsed] = Flow[Long].map { l => batchQueue.add(l); l }
+  }
+
+  object PerpStreamActors {
+    // TODO Can I not put these within the test:(:(
+    // Seems like I can't due to some Akka actor construction rule.
+
+    class SinkMaterializingStream extends PerpStream[Sink[Long, NotUsed]] {
+      self ! Active
+      override def streamGraph =
+        MergeHub.source[Long].via(addToBatch).to(Sink.ignore)
+    }
+
+    /**
+      * This has Sink[T, NotUsed] as the materialized value's first element.
+      */
+    class GoodProductSinkMaterializingStream extends PerpStream[(Sink[Long, NotUsed], Future[akka.Done])] {
+      self ! Active
+      override def streamGraph = {
+        RunnableGraph.fromGraph(GraphDSL.create(MergeHub.source[Long], Sink.ignore)((_, _)) { implicit builder =>
+          (mergeHubSource, sink) =>
+            import GraphDSL.Implicits._
+            mergeHubSource ~> addToBatch ~> sink
+            ClosedShape
+        })
+      }
+    }
+
+    /**
+      * This materializes a product that does NOT have Sink[T, NotUsed] as its first element.
+      */
+    class BadProductSinkMaterializingStream extends PerpStream[(Int, Any)] {
+      self ! Active
+      override def streamGraph = Source.single(1).toMat(Sink.ignore)((_, _) => (1, 2))
+    }
+
+    /**
+      * This materializes an Int (neither a Sink[T, NotUsed] or a product).
+      */
+    class IntProducingStream extends PerpStream[Int] {
+      self ! Active
+      override def streamGraph = Source.single(1).toMat(Sink.ignore)((_, _) => 6)
+    }
+  }
+
+  class SomeActor(perpStream: ActorRef) extends Actor with PerpetualStreamMatValue[Long] {
+    implicit val mat = ActorMaterializer()
+
+    override def actorLookup(name: String)(implicit refFactory: ActorRefFactory, timeout: Timeout) =
+      perpStream
+
+    override def receive: Receive = {
+      case l: Long => sender() ! Try { Source.single(l).to(matValue("any-name-works-see-impl")).run() }
+    }
   }
 }

--- a/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/stream/PerpetualStreamSpec.scala
@@ -15,23 +15,15 @@
  */
 package org.squbs.stream
 
-import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
-
-import akka.NotUsed
-import akka.actor.{Actor, ActorRef, ActorRefFactory, ActorSystem, Props}
+import akka.actor.{ActorSystem}
 import akka.pattern._
-import akka.stream.{ActorMaterializer, ClosedShape}
-import akka.stream.scaladsl.{Flow, GraphDSL, MergeHub, RunnableGraph, Sink, Source}
-import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.OptionValues._
 import org.scalatest.{FlatSpec, Matchers}
 import org.squbs.lifecycle.GracefulStop
 import org.squbs.unicomplex._
 
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, Future}
-import scala.util.{Failure, Success, Try}
 
 class PerpetualStreamSpec extends FlatSpec with Matchers {
 
@@ -165,135 +157,5 @@ class PerpetualStreamSpec extends FlatSpec with Matchers {
     val count = Await.result(countF, awaitMax)
     println(s"Counts -> src: ${genCount.get} dest: $count")
     count shouldBe genCount.get
-  }
-
-  "PerpetualStreamMatValue's matValue(String)" should "return a Sink[T, NotUsed] " +
-    "when the referenced perpetualstream's mat value is a Sink[T, NotUsed]" in {
-    import PerpetualStreamMatValueSpecHelper._
-    val to = FiniteDuration(1, TimeUnit.SECONDS)
-    useSystem(classOf[PerpStreamActors.SinkMaterializingStream]) { case Right(actor) =>
-      implicit val timeout = Timeout(to)
-      val queue = Await.result((actor ? Queue).mapTo[LinkedBlockingQueue[Long]], to)
-      queue.poll(1, TimeUnit.SECONDS) should be(PerpetualStreamMatValueSpecHelper.payload)
-    }
-  }
-
-  it should "return a Sink[T, NotUsed] when the referenced perpetualstream's " +
-    "mat value is a product where the first 'element' is Sink[T, NotUsed]" in {
-    import PerpetualStreamMatValueSpecHelper._
-    val to = FiniteDuration(1, TimeUnit.SECONDS)
-    useSystem(classOf[PerpStreamActors.GoodProductSinkMaterializingStream]) { case Right(actor) =>
-      implicit val timeout = Timeout(to)
-      val queue = Await.result((actor ? Queue).mapTo[LinkedBlockingQueue[Long]], to)
-      queue.poll(1, TimeUnit.SECONDS) should be(PerpetualStreamMatValueSpecHelper.payload)
-    }
-  }
-
-  it should "throw a ClassCastException when the referenced perpetualstream's " +
-    "mat value is a product and the first 'element' is NOT a Sink[T, NotUsed]" in {
-    import PerpetualStreamMatValueSpecHelper._
-    useSystem(classOf[PerpStreamActors.BadProductSinkMaterializingStream]) { case Left(e) =>
-      e shouldBe a[ClassCastException]
-      e.getMessage should be(
-        s"Materialized value mismatch. First element should be a Sink. Found ${classOf[Integer].getName}."
-      )
-    }
-  }
-
-  it should "throw a ClassCastException when the referenced perpetualstream's " +
-    "mat value is anything else" in {
-    import PerpetualStreamMatValueSpecHelper._
-    useSystem(classOf[PerpStreamActors.IntProducingStream]) { case Left(e) =>
-      e shouldBe a[ClassCastException]
-      e.getMessage should be(
-        s"Materialized value mismatch. Should be a Sink. Found ${classOf[Integer].getName}."
-      )
-    }
-  }
-}
-
-object PerpetualStreamMatValueSpecHelper {
-
-  import scala.concurrent.duration._
-  val payload = 1L
-  case object Queue
-  implicit val timeout = Timeout(1.second)
-
-  def useSystem[PC <: PerpStream[_]](perpStream: Class[PC])(fn: Either[Throwable, ActorRef] => Unit): Unit = {
-    implicit val actorSystem = ActorSystem()
-    implicit val materializer = ActorMaterializer()
-
-    // TODO Is it ok to violate actor creation guidelines here?
-    val perpRef = actorSystem.actorOf(Props(perpStream), "act1")
-    val someRef = actorSystem.actorOf(Props(new SomeActor(perpRef)), "act2")
-
-    Await.result(someRef ? payload, 1.second) match {
-      case Success(_) => fn(Right(perpRef))
-      case Failure(e) => fn(Left(e))
-    }
-    actorSystem.terminate()
-  }
-
-  trait PerpStream[T] extends PerpetualStream[T] {
-    val batchQueue = new LinkedBlockingQueue[Long]()
-    // https://stackoverflow.com/a/18469420
-    override def receive= ({
-      case Queue => sender() ! batchQueue
-    }: Receive) orElse super.receive
-
-    def addToBatch: Flow[Long, Long, NotUsed] = Flow[Long].map { l => batchQueue.add(l); l }
-  }
-
-  object PerpStreamActors {
-    // TODO Can I not put these within the test:(:(
-    // Seems like I can't due to some Akka actor construction rule.
-
-    class SinkMaterializingStream extends PerpStream[Sink[Long, NotUsed]] {
-      self ! Active
-      override def streamGraph =
-        MergeHub.source[Long].via(addToBatch).to(Sink.ignore)
-    }
-
-    /**
-      * This has Sink[T, NotUsed] as the materialized value's first element.
-      */
-    class GoodProductSinkMaterializingStream extends PerpStream[(Sink[Long, NotUsed], Future[akka.Done])] {
-      self ! Active
-      override def streamGraph = {
-        RunnableGraph.fromGraph(GraphDSL.create(MergeHub.source[Long], Sink.ignore)((_, _)) { implicit builder =>
-          (mergeHubSource, sink) =>
-            import GraphDSL.Implicits._
-            mergeHubSource ~> addToBatch ~> sink
-            ClosedShape
-        })
-      }
-    }
-
-    /**
-      * This materializes a product that does NOT have Sink[T, NotUsed] as its first element.
-      */
-    class BadProductSinkMaterializingStream extends PerpStream[(Int, Any)] {
-      self ! Active
-      override def streamGraph = Source.single(1).toMat(Sink.ignore)((_, _) => (1, 2))
-    }
-
-    /**
-      * This materializes an Int (neither a Sink[T, NotUsed] or a product).
-      */
-    class IntProducingStream extends PerpStream[Int] {
-      self ! Active
-      override def streamGraph = Source.single(1).toMat(Sink.ignore)((_, _) => 6)
-    }
-  }
-
-  class SomeActor(perpStream: ActorRef) extends Actor with PerpetualStreamMatValue[Long] {
-    implicit val mat = ActorMaterializer()
-
-    override def actorLookup(name: String)(implicit refFactory: ActorRefFactory, timeout: Timeout) =
-      perpStream
-
-    override def receive: Receive = {
-      case l: Long => sender() ! Try { Source.single(l).to(matValue("any-name-works-see-impl")).run() }
-    }
   }
 }


### PR DESCRIPTION
that materialize to `Sink[T, NotUsed]` or to any `Product` whose first element
is a `Sink[T, NotUsed]`.


Thanks for your pull request.  Please review the following guidelines.

- [X] Title includes issue id.
- [X] Description of the change added.
- [X] Commits are squashed.
- [X] Tests added.
- [ ] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
