### PR TITLE
695: Bump dependency versions to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Shared._
 
-scalaVersion in ThisBuild := "2.12.6"
+scalaVersion in ThisBuild := "2.12.8"
 
 organization in ThisBuild := "org.squbs"
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -15,19 +15,19 @@
  */
 
 object Versions {
-  val akkaV = "2.5.13"
-  val akkaHttpV = "10.1.3"
+  val akkaV = "2.5.19"
+  val akkaHttpV = "10.1.7"
   val scalatestV = "3.0.5"
-  val scalaLoggingV = "3.9.0"
-  val jacksonV = "2.9.5"
-  val json4sV = "3.5.3"
-  val heikoseebergerAkkaHttpJsonV = "1.20.1"
-  val metricsV = "4.0.2"
+  val scalaLoggingV = "3.9.2"
+  val jacksonV = "2.9.8"
+  val json4sV = "3.6.3"
+  val heikoseebergerAkkaHttpJsonV = "1.24.3"
+  val metricsV = "4.0.5"
   val junitInterfaceV = "0.11"
   val junitV = "4.12"
   val testngV = "6.14.3"
-  val accordV = "0.7.2"
+  val accordV = "0.7.3"
   val chronicleQueueV = "4.16.5"
   val logbackInTestV = "1.2.3"
-  val curatorV = "4.0.1"
+  val curatorV = "4.1.0"
 }

--- a/squbs-pattern/src/test/scala/org/squbs/pattern/stream/BroadcastBufferSpec.scala
+++ b/squbs-pattern/src/test/scala/org/squbs/pattern/stream/BroadcastBufferSpec.scala
@@ -182,7 +182,8 @@ abstract class BroadcastBufferSpec[T: ClassTag, Q <: QueueSerializer[T] : Manife
     val graph = RunnableGraph.fromGraph(
       GraphDSL.create(Sink.ignore, Sink.ignore)((_, _)) { implicit builder => (sink1, sink2) =>
           import GraphDSL.Implicits._
-          val buffer = new BroadcastBuffer[T](config).withOnPushCallback(() => inCounter.incrementAndGet())
+          val buffer = new BroadcastBuffer[T](config)
+            .withOnPushCallback(() => inCounter.incrementAndGet())
             .withOnCommitCallback(i => commitCounter(i))
           val bcBuffer = builder.add(buffer.async)
 

--- a/squbs-pattern/src/test/scala/org/squbs/pattern/stream/BroadcastBufferSpec.scala
+++ b/squbs-pattern/src/test/scala/org/squbs/pattern/stream/BroadcastBufferSpec.scala
@@ -182,7 +182,8 @@ abstract class BroadcastBufferSpec[T: ClassTag, Q <: QueueSerializer[T] : Manife
     val graph = RunnableGraph.fromGraph(
       GraphDSL.create(Sink.ignore, Sink.ignore)((_, _)) { implicit builder => (sink1, sink2) =>
           import GraphDSL.Implicits._
-          val buffer = new BroadcastBuffer[T](config).withOnPushCallback(() => inCounter.incrementAndGet()).withOnCommitCallback(i => commitCounter(i))
+          val buffer = new BroadcastBuffer[T](config).withOnPushCallback(() => inCounter.incrementAndGet())
+            .withOnCommitCallback(i => commitCounter(i))
           val bcBuffer = builder.add(buffer.async)
 
           in ~> transform ~> bcBuffer ~> throttle ~> injectError ~> sink1

--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/ListenerStateSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/ListenerStateSpec.scala
@@ -115,7 +115,7 @@ class ListenerStateSpec extends TestKit(ListenerStateSpec.boot.actorSystem) with
 
     defaultListener.get("state") should be("Success")
     portConflictListener.get("state") should be("Failed")
-    portConflictListener.get("error").asInstanceOf[String] should endWith("Bind failed because of Address already in use")
+    portConflictListener.get("error").asInstanceOf[String] should endWith("Bind failed because of java.net.BindException: Address already in use")
     sslContextNotExistListener.get("state") should be("Failed")
     sslContextNotExistListener.get("error").asInstanceOf[String] should startWith("java.lang.ClassNotFoundException: org.squbs.unicomplex.IDoNotExist")
   }

--- a/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/MaterializerSpec.scala
+++ b/squbs-unicomplex/src/test/scala/org/squbs/unicomplex/MaterializerSpec.scala
@@ -110,6 +110,7 @@ object MaterializerSpec {
       |  buffer-capacity = 32
       |  demand-redelivery-interval = 1 second
       |  subscription-timeout = 30 seconds
+      |  final-termination-signal-deadline = 2 seconds
       |}
       |blocking-io-dispatcher = "akka.stream.default-blocking-io-dispatcher"
     """.stripMargin)

--- a/squbs-zkcluster/build.sbt
+++ b/squbs-zkcluster/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
   "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
   "org.scalatest" %% "scalatest" % scalatestV % "test->*",
-  "org.mockito" % "mockito-core" % "2.18.3" % "test",
+  "org.mockito" % "mockito-core" % "2.23.4" % "test",
   "org.apache.curator" % "curator-test" % curatorV % "test",
   "ch.qos.logback" % "logback-classic" % logbackInTestV % "test"
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.1-SNAPSHOT"
+version in ThisBuild := "0.12.0-SNAPSHOT"


### PR DESCRIPTION
#695: Bump dependency versions to latest versions of akka, akka-http etc.
Also minor test updates to fix issues introduced.


Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [x] Tests added.
- [ ] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
