### PR TITLE
Standardized Java Duration and their conversions (fixes #694).

### DIFF
--- a/docs/flow-timeout.md
+++ b/docs/flow-timeout.md
@@ -43,7 +43,7 @@ Source("a" :: "b" :: "c" :: Nil)
 ##### Java
 
 ```java
-final FiniteDuration duration = Duration.create(1, TimeUnit.SECONDS);
+final Duration duration = Duration.ofSeconds(1);
 
 final BidiFlow<String, String, String, Try<String>, NotUsed> timeout = TimeoutOrdered.create(duration);
 
@@ -93,7 +93,7 @@ public class Timeout {
 This `BidiFlow` can be joined with any flow that takes in a `akka.japi.Pair<In, Context>` and outputs a `akka.japi.Pair<Out, Context>`.
 
 ```java
-final FiniteDuration duration = Duration.create(1, TimeUnit.SECONDS);
+final Duration duration = Duration.ofSeconds(1);
 
 final BidiFlow<Pair<String, UUID>,
                Pair<String, UUID>,
@@ -164,7 +164,7 @@ class MyContext {
     }
 }
 
-final FiniteDuration duration = Duration.create(1, TimeUnit.SECONDS);
+final Duration duration = Duration.ofSeconds(1);
 
 final TimeoutSettings settings =
     TimeoutSettings.<String, String, Context>create(duration)
@@ -206,7 +206,7 @@ val timeout = Timeout(settings)
 
 ###### Java
 ```java
-final FiniteDuration duration = Duration.create(20, TimeUnit.MILLISECONDS);
+final Duration duration = Duration.ofMillis(20);
 
 final TimeoutSettings settings =
     TimeoutSettings.<HttpRequest, HttpResponse, Context>create(duration)

--- a/docs/timeoutpolicy.md
+++ b/docs/timeoutpolicy.md
@@ -77,7 +77,7 @@ In the Java API, we create the timeout policy using a policy builder, as can be 
 
    ```java
    TimeoutPolicy fixedTimeoutPolicy = TimeoutPolicyBuilder
-       .create(new FiniteDuration(INITIAL_TIMEOUT, MILLISECONDS), fromExecutorService(es))
+       .create(Duration.ofMillis(INITIAL_TIMEOUT), fromExecutorService(es))
        .minSamples(1)
        .rule(TimeoutPolicyType.FIXED)
        .build();
@@ -87,7 +87,7 @@ In the Java API, we create the timeout policy using a policy builder, as can be 
  
    ```java
    TimeoutPolicy sigmaTimeoutPolicy = TimeoutPolicyBuilder
-       .create(new FiniteDuration(INITIAL_TIMEOUT, MILLISECONDS), system.dispatcher())
+       .create(Duration.ofMillis(INITIAL_TIMEOUT), system.dispatcher())
        .minSamples(1)
        .name("MySigmaPolicy")
        .rule(3.0, TimeoutPolicyType.SIGMA)
@@ -98,7 +98,7 @@ In the Java API, we create the timeout policy using a policy builder, as can be 
 
    ```java
    TimeoutPolicy percentileTimeoutPolicy = TimeoutPolicyBuilder
-       .create(new FiniteDuration(INITIAL_TIMEOUT, MILLISECONDS), system.dispatcher())
+       .create(Duration.ofMillis(INITIAL_TIMEOUT),, system.dispatcher())
        .minSamples(1)
        .name("PERCENTILE")
        .rule(95, TimeoutPolicyType.PERCENTILE)
@@ -108,7 +108,7 @@ In the Java API, we create the timeout policy using a policy builder, as can be 
 Then, to use the timeout policy, just execute your timed call inside the closure as follows:
 
 ```java
-policy.execute((FiniteDuration t) -> {
+policy.execute((Duration t) -> {
     return es.submit(timedCall).get(t.toMillis() + 20, MILLISECONDS);
 });
 ```
@@ -118,7 +118,7 @@ Or, you can use the non-closure version of the call as follows:
 ```java
 TimeoutPolicy.TimeoutTransaction tx = policy.transaction();
 try {
-  return timedFn.get(tx.waitTime());
+  return timedFn.get(Duration.ofMillis(tx.waitTime().toMillis()));
 } catch (Exception e) {
   System.out.println(e);
 } finally {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -15,7 +15,7 @@
  */
 
 object Versions {
-  val akkaV = "2.5.20"
+  val akkaV = "2.5.21"
   val akkaHttpV = "10.1.7"
   val scalatestV = "3.0.5"
   val scalaLoggingV = "3.9.0"

--- a/squbs-ext/src/main/scala/org/squbs/streams/Timeout.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/Timeout.scala
@@ -27,6 +27,7 @@ import akka.stream._
 import akka.stream.scaladsl.{BidiFlow, Flow}
 import akka.stream.stage.{GraphStage, _}
 import com.typesafe.scalalogging.LazyLogging
+import org.squbs.util.DurationConverters
 import org.squbs.streams.TimeoutBidi._
 
 import scala.collection.mutable
@@ -193,7 +194,7 @@ object Timeout {
     */
   def create[In, Out, Context](timeout: java.time.Duration):
   javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] =
-    toJava(apply[In, Out, Context](FiniteDuration(timeout.toMillis, TimeUnit.MILLISECONDS)))
+    toJava(apply[In, Out, Context](DurationConverters.toScala(timeout)))
 
 }
 
@@ -355,7 +356,7 @@ object TimeoutOrdered {
   def create[In, Out](timeout: java.time.Duration,
                       cleanUp: Consumer[Out]):
   akka.stream.javadsl.BidiFlow[In, In, Out, Try[Out], NotUsed] = {
-    apply(FiniteDuration(timeout.toMillis, TimeUnit.MILLISECONDS), (out: Out) => cleanUp.accept(out)).asJava
+    apply(DurationConverters.toScala(timeout), (out: Out) => cleanUp.accept(out)).asJava
   }
 
   /**
@@ -367,7 +368,7 @@ object TimeoutOrdered {
     */
   def create[In, Out](timeout: java.time.Duration):
   akka.stream.javadsl.BidiFlow[In, In, Out, Try[Out], NotUsed] = {
-    apply(FiniteDuration(timeout.toMillis, TimeUnit.MILLISECONDS), (_: Out) => ()).asJava
+    apply(DurationConverters.toScala(timeout), (_: Out) => ()).asJava
   }
 }
 

--- a/squbs-ext/src/main/scala/org/squbs/streams/Timeout.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/Timeout.scala
@@ -17,7 +17,7 @@
 package org.squbs.streams
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.{TimeUnit, TimeoutException}
 import java.util.function.Consumer
 
 import akka.NotUsed
@@ -191,9 +191,9 @@ object Timeout {
   /**
     * Java API
     */
-  def create[In, Out, Context](timeout: FiniteDuration):
+  def create[In, Out, Context](timeout: java.time.Duration):
   javadsl.BidiFlow[Pair[In, Context], Pair[In, Context], Pair[Out, Context], Pair[Try[Out], Context], NotUsed] =
-    toJava(apply[In, Out, Context](timeout))
+    toJava(apply[In, Out, Context](FiniteDuration(timeout.toMillis, TimeUnit.MILLISECONDS)))
 
 }
 
@@ -233,7 +233,8 @@ object TimeoutSettings {
   /**
     * Java API
     */
-  def create[In, Out, Context](timeout: FiniteDuration): TimeoutSettings[In, Out, Context] = apply(timeout)
+  def create[In, Out, Context](timeout: java.time.Duration): TimeoutSettings[In, Out, Context] =
+    apply(FiniteDuration(timeout.toMillis, TimeUnit.MILLISECONDS))
 }
 
 /**
@@ -351,15 +352,22 @@ object TimeoutOrdered {
   /**
     * Java API
     */
-  def create[In, Out](timeout: FiniteDuration,
+  def create[In, Out](timeout: java.time.Duration,
                       cleanUp: Consumer[Out]):
   akka.stream.javadsl.BidiFlow[In, In, Out, Try[Out], NotUsed] = {
-    apply(timeout, (out: Out) => cleanUp.accept(out)).asJava
+    apply(FiniteDuration(timeout.toMillis, TimeUnit.MILLISECONDS), (out: Out) => cleanUp.accept(out)).asJava
   }
 
-  def create[In, Out](timeout: FiniteDuration):
+  /**
+    * Java API
+    * @param timeout
+    * @tparam In
+    * @tparam Out
+    * @return
+    */
+  def create[In, Out](timeout: java.time.Duration):
   akka.stream.javadsl.BidiFlow[In, In, Out, Try[Out], NotUsed] = {
-    apply(timeout, (_: Out) => ()).asJava
+    apply(FiniteDuration(timeout.toMillis, TimeUnit.MILLISECONDS), (_: Out) => ()).asJava
   }
 }
 

--- a/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/impl/AtomicCircuitBreakerState.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/impl/AtomicCircuitBreakerState.scala
@@ -20,6 +20,7 @@
 package org.squbs.streams.circuitbreaker.impl
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.util.Unsafe
@@ -87,11 +88,15 @@ object AtomicCircuitBreakerState {
     */
   def create(name: String,
              maxFailures: Int,
-             callTimeout: FiniteDuration,
-             resetTimeout: FiniteDuration,
+             callTimeout: java.time.Duration,
+             resetTimeout: java.time.Duration,
              executor: ExecutionContext,
              scheduler: Scheduler): CircuitBreakerState =
-    apply(name, maxFailures, callTimeout, resetTimeout)(executor, scheduler)
+    apply(name,
+      maxFailures,
+      FiniteDuration(callTimeout.toMillis, TimeUnit.MILLISECONDS),
+      FiniteDuration(resetTimeout.toMillis, TimeUnit.MILLISECONDS)
+    )(executor, scheduler)
 
   /**
     * Java API
@@ -108,13 +113,19 @@ object AtomicCircuitBreakerState {
     */
   def create(name: String,
              maxFailures: Int,
-             callTimeout: FiniteDuration,
-             resetTimeout: FiniteDuration,
-             maxResetTimeout: FiniteDuration,
+             callTimeout: java.time.Duration,
+             resetTimeout: java.time.Duration,
+             maxResetTimeout: java.time.Duration,
              exponentialBackoffFactor: Double,
              executor: ExecutionContext,
              scheduler: Scheduler): CircuitBreakerState =
-    apply(name, maxFailures, callTimeout, resetTimeout, maxResetTimeout, exponentialBackoffFactor)(executor, scheduler)
+    apply(name,
+      maxFailures,
+      FiniteDuration(callTimeout.toMillis, TimeUnit.MILLISECONDS),
+      FiniteDuration(resetTimeout.toMillis, TimeUnit.MILLISECONDS),
+      FiniteDuration(maxResetTimeout.toMillis, TimeUnit.MILLISECONDS),
+      exponentialBackoffFactor
+    )(executor, scheduler)
 
   /**
     * Java API

--- a/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/impl/AtomicCircuitBreakerState.scala
+++ b/squbs-ext/src/main/scala/org/squbs/streams/circuitbreaker/impl/AtomicCircuitBreakerState.scala
@@ -32,6 +32,8 @@ import org.squbs.metrics.MetricsExtension
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
+import org.squbs.util.DurationConverters._
+
 object AtomicCircuitBreakerState {
 
   /**
@@ -92,11 +94,7 @@ object AtomicCircuitBreakerState {
              resetTimeout: java.time.Duration,
              executor: ExecutionContext,
              scheduler: Scheduler): CircuitBreakerState =
-    apply(name,
-      maxFailures,
-      FiniteDuration(callTimeout.toMillis, TimeUnit.MILLISECONDS),
-      FiniteDuration(resetTimeout.toMillis, TimeUnit.MILLISECONDS)
-    )(executor, scheduler)
+    apply(name, maxFailures, toScala(callTimeout), toScala(resetTimeout))(executor, scheduler)
 
   /**
     * Java API
@@ -119,13 +117,8 @@ object AtomicCircuitBreakerState {
              exponentialBackoffFactor: Double,
              executor: ExecutionContext,
              scheduler: Scheduler): CircuitBreakerState =
-    apply(name,
-      maxFailures,
-      FiniteDuration(callTimeout.toMillis, TimeUnit.MILLISECONDS),
-      FiniteDuration(resetTimeout.toMillis, TimeUnit.MILLISECONDS),
-      FiniteDuration(maxResetTimeout.toMillis, TimeUnit.MILLISECONDS),
-      exponentialBackoffFactor
-    )(executor, scheduler)
+    apply(name, maxFailures, toScala(callTimeout), toScala(resetTimeout), toScala(maxResetTimeout),
+      exponentialBackoffFactor)(executor, scheduler)
 
   /**
     * Java API

--- a/squbs-ext/src/main/scala/org/squbs/util/DurationConverters.scala
+++ b/squbs-ext/src/main/scala/org/squbs/util/DurationConverters.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2012-2017 Typesafe Inc. <http://www.typesafe.com>
+ */
+package org.squbs.util
+
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import java.time.{Duration => JavaDuration}
+
+import scala.concurrent.duration.{FiniteDuration, Duration => ScalaDuration}
+
+
+/**
+  * This class contains static methods which convert between Java Durations
+  * and the durations from the Scala concurrency package. This is useful when mediating between Scala and Java
+  * libraries with asynchronous APIs where timeouts for example are often expressed as durations.
+  */
+object DurationConverters {
+
+  /**
+    * Transform a Java duration into a Scala duration. If the nanosecond part of the Java duration is zero the returned
+    * duration will have a time unit of seconds and if nthere is a nanoseconds part the Scala duration will have a time
+    * unit of nanoseconds.
+    *
+    * @throws IllegalArgumentException If the given Java Duration is out of bounds of what can be expressed with the
+    *                                  Scala FiniteDuration.
+    */
+  final def toScala(duration: java.time.Duration): scala.concurrent.duration.FiniteDuration = {
+    val originalSeconds = duration.getSeconds
+    val originalNanos = duration.getNano
+    if (originalNanos == 0) {
+      if (originalSeconds == 0) ScalaDuration.Zero
+      else FiniteDuration(originalSeconds, TimeUnit.SECONDS).toCoarsest.asInstanceOf[FiniteDuration]
+    } else if (originalSeconds == 0) {
+      FiniteDuration(originalNanos, TimeUnit.NANOSECONDS).toCoarsest.asInstanceOf[FiniteDuration]
+    } else {
+      try {
+        val secondsAsNanos = Math.multiplyExact(originalSeconds, 1000000000)
+        val totalNanos = secondsAsNanos + originalNanos
+        if ((totalNanos < 0 && secondsAsNanos < 0) || (totalNanos > 0 && secondsAsNanos > 0))
+          FiniteDuration(totalNanos, TimeUnit.NANOSECONDS).toCoarsest.asInstanceOf[FiniteDuration]
+        else
+          throw new ArithmeticException()
+      } catch {
+        case _: ArithmeticException =>
+          throw new IllegalArgumentException(s"Java duration $duration cannot be expressed as a Scala duration")
+      }
+    }
+  }
+
+  /**
+    * Transform a Scala FiniteDuration into a Java duration. Note that the Scala duration keeps the time unit it was created
+    * with while a Java duration always is a pair of seconds and nanos, so the unit it lost.
+    */
+  final def toJava(duration: scala.concurrent.duration.FiniteDuration): java.time.Duration = {
+    if (duration.length == 0) JavaDuration.ZERO
+    else duration.unit match {
+      case TimeUnit.NANOSECONDS => JavaDuration.ofNanos(duration.length)
+      case TimeUnit.MICROSECONDS => JavaDuration.of(duration.length, ChronoUnit.MICROS)
+      case TimeUnit.MILLISECONDS => JavaDuration.ofMillis(duration.length)
+      case TimeUnit.SECONDS => JavaDuration.ofSeconds(duration.length)
+      case TimeUnit.MINUTES => JavaDuration.ofMinutes(duration.length)
+      case TimeUnit.HOURS => JavaDuration.ofHours(duration.length)
+      case TimeUnit.DAYS => JavaDuration.ofDays(duration.length)
+    }
+  }
+}

--- a/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerStateTest.java
+++ b/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerStateTest.java
@@ -66,7 +66,7 @@ public class CircuitBreakerStateTest {
         assertJmxValue("java-params-with-custom-exponential-backoff", "MaxFailures", 1);
         assertJmxValue("java-params-with-custom-exponential-backoff", "CallTimeout", "50 milliseconds");
         assertJmxValue("java-params-with-custom-exponential-backoff", "ResetTimeout", "20 milliseconds");
-        assertJmxValue("java-params-with-custom-exponential-backoff", "MaxResetTimeout", "120000 milliseconds"); // 2 minutes
+        assertJmxValue("java-params-with-custom-exponential-backoff", "MaxResetTimeout", "2 minutes");
         assertJmxValue("java-params-with-custom-exponential-backoff", "ExponentialBackoffFactor", 16.0);
     }
 

--- a/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerStateTest.java
+++ b/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerStateTest.java
@@ -23,11 +23,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.squbs.streams.circuitbreaker.impl.AtomicCircuitBreakerState;
-import scala.concurrent.duration.Duration;
 
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 public class CircuitBreakerStateTest {
 
@@ -43,8 +42,8 @@ public class CircuitBreakerStateTest {
         AtomicCircuitBreakerState.create(
                 "java-params-with-default-exponential-backoff",
                 1,
-                Duration.create(50, TimeUnit.MILLISECONDS),
-                Duration.create(20, TimeUnit.MILLISECONDS),
+                Duration.ofMillis(50),
+                Duration.ofMillis(20),
                 system.dispatcher(),
                 system.scheduler());
         assertJmxValue("java-params-with-default-exponential-backoff", "MaxFailures", 1);
@@ -58,16 +57,16 @@ public class CircuitBreakerStateTest {
     public void testCreateCircuitBreakerStateWithExponentialBackoff() throws Exception {
         AtomicCircuitBreakerState.create(
                 "java-params-with-custom-exponential-backoff", 1,
-                Duration.create(50, TimeUnit.MILLISECONDS),
-                Duration.create(20, TimeUnit.MILLISECONDS),
-                Duration.create(2, TimeUnit.MINUTES),
+                Duration.ofMillis(50),
+                Duration.ofMillis(20),
+                Duration.ofMinutes(2),
                 16.0,
                 system.dispatcher(),
                 system.scheduler());
         assertJmxValue("java-params-with-custom-exponential-backoff", "MaxFailures", 1);
         assertJmxValue("java-params-with-custom-exponential-backoff", "CallTimeout", "50 milliseconds");
         assertJmxValue("java-params-with-custom-exponential-backoff", "ResetTimeout", "20 milliseconds");
-        assertJmxValue("java-params-with-custom-exponential-backoff", "MaxResetTimeout", "2 minutes");
+        assertJmxValue("java-params-with-custom-exponential-backoff", "MaxResetTimeout", "120000 milliseconds"); // 2 minutes
         assertJmxValue("java-params-with-custom-exponential-backoff", "ExponentialBackoffFactor", 16.0);
     }
 

--- a/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerTest.java
+++ b/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerTest.java
@@ -37,18 +37,16 @@ import org.squbs.streams.FlowTimeoutException;
 import org.squbs.streams.Timing;
 import org.squbs.streams.circuitbreaker.impl.AtomicCircuitBreakerState;
 import org.squbs.streams.circuitbreaker.japi.CircuitBreakerSettings;
-import scala.concurrent.duration.Duration;
-import scala.concurrent.duration.FiniteDuration;
 import scala.util.Failure;
 import scala.util.Success;
 import scala.util.Try;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -58,7 +56,7 @@ public class CircuitBreakerTest {
 
     private static final ActorSystem system = ActorSystem.create("CircuitBreakerTest");
     private static final Materializer mat = ActorMaterializer.create(system);
-    private static final FiniteDuration timeout = Duration.create(300, TimeUnit.MILLISECONDS);
+    private static final Duration timeout = Duration.ofMillis(300);
     private static final Try<String> timeoutFailure = Failure.apply(new FlowTimeoutException("Flow timed out!"));
 
     @AfterClass
@@ -80,7 +78,7 @@ public class CircuitBreakerTest {
                         "JavaIncFailCount",
                         2,
                         timeout,
-                        Duration.create(10, TimeUnit.MILLISECONDS),
+                        Duration.ofMillis(10),
                         system.dispatcher(),
                         system.scheduler());
 
@@ -114,8 +112,8 @@ public class CircuitBreakerTest {
                 AtomicCircuitBreakerState.create(
                         "JavaFailureDecider",
                         2,
-                        Duration.create(10, TimeUnit.SECONDS),
-                        Duration.create(10, TimeUnit.MILLISECONDS),
+                        Duration.ofSeconds(10),
+                        Duration.ofMillis(10),
                         system.dispatcher(),
                         system.scheduler());
 
@@ -165,8 +163,8 @@ public class CircuitBreakerTest {
                 AtomicCircuitBreakerState.create(
                         "JavaFallback",
                         2,
-                        Duration.create(10, TimeUnit.MILLISECONDS),
-                        Duration.create(10, TimeUnit.SECONDS),
+                        Duration.ofMillis(10),
+                        Duration.ofSeconds(10),
                         system.dispatcher(),
                         system.scheduler());
 
@@ -247,7 +245,7 @@ public class CircuitBreakerTest {
                         "JavaUniqueId",
                         2,
                         timeout,
-                        Duration.create(10, TimeUnit.MILLISECONDS),
+                        Duration.ofMillis(10),
                         system.dispatcher(),
                         system.scheduler());
 
@@ -323,8 +321,8 @@ public class CircuitBreakerTest {
                 AtomicCircuitBreakerState.create(
                         "JavaUniqueId",
                         2,
-                        Timing.timeout(),
-                        Duration.create(10, TimeUnit.MILLISECONDS),
+                        Duration.ofSeconds(Timing.timeout().toSeconds()),
+                        Duration.ofMillis(10),
                         system.dispatcher(),
                         system.scheduler());
 
@@ -363,7 +361,7 @@ public class CircuitBreakerTest {
                         "JavaFailureDecider",
                         2,
                         timeout,
-                        Duration.create(10, TimeUnit.MILLISECONDS),
+                        Duration.ofMillis(10),
                         system.dispatcher(),
                         system.scheduler());
 

--- a/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowTest.java
+++ b/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowTest.java
@@ -142,9 +142,9 @@ public class ClientFlowTest {
         assertJmxValue(oNameHC, "MaxConnections", 41);
         assertJmxValue(oNameHC, "Environment", "PROD");
         assertJmxValue(oNameCB, "MaxFailures", 11);
-        assertJmxValue(oNameCB, "CallTimeout", "12000 milliseconds"); // 12 seconds
-        assertJmxValue(oNameCB, "ResetTimeout", "780000 milliseconds"); // 13 minutes
-        assertJmxValue(oNameCB, "MaxResetTimeout", "1209600000 milliseconds"); // 14 days
+        assertJmxValue(oNameCB, "CallTimeout", "12 seconds");
+        assertJmxValue(oNameCB, "ResetTimeout", "13 minutes");
+        assertJmxValue(oNameCB, "MaxResetTimeout", "14 days");
         assertJmxValue(oNameCB, "ExponentialBackoffFactor", 16.0);
     }
 
@@ -189,9 +189,9 @@ public class ClientFlowTest {
         assertJmxValue(oNameHC, "MaxConnections", 41);
         assertJmxValue(oNameHC, "Environment", "PROD");
         assertJmxValue(oNameCB, "MaxFailures", 11);
-        assertJmxValue(oNameCB, "CallTimeout", "12000 milliseconds"); // 12 seconds
-        assertJmxValue(oNameCB, "ResetTimeout", "780000 milliseconds"); // 13 minutes
-        assertJmxValue(oNameCB, "MaxResetTimeout", "1209600000 milliseconds"); // 14 days
+        assertJmxValue(oNameCB, "CallTimeout", "12 seconds");
+        assertJmxValue(oNameCB, "ResetTimeout", "13 minutes");
+        assertJmxValue(oNameCB, "MaxResetTimeout", "14 days");
         assertJmxValue(oNameCB, "ExponentialBackoffFactor", 16.0);
     }
 

--- a/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowTest.java
+++ b/squbs-httpclient/src/test/java/org/squbs/httpclient/ClientFlowTest.java
@@ -34,15 +34,14 @@ import org.squbs.resolver.ResolverRegistry;
 import org.squbs.streams.circuitbreaker.impl.AtomicCircuitBreakerState;
 import org.squbs.streams.circuitbreaker.japi.CircuitBreakerSettings;
 import org.squbs.testkit.Timeouts;
-import scala.concurrent.duration.FiniteDuration;
 import scala.util.Try;
 
 import javax.management.ObjectName;
 import javax.net.ssl.SSLContext;
 import java.lang.management.ManagementFactory;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -119,9 +118,9 @@ public class ClientFlowTest {
                         AtomicCircuitBreakerState.create(
                                 "javaBuilderClient",
                                 11,
-                                FiniteDuration.apply(12, TimeUnit.SECONDS),
-                                FiniteDuration.apply(13, TimeUnit.MINUTES),
-                                FiniteDuration.apply(14, TimeUnit.DAYS),
+                                Duration.ofSeconds(12),
+                                Duration.ofMinutes(13),
+                                Duration.ofDays(14),
                                 16.0,
                                 system.dispatcher(),
                                 system.scheduler()));
@@ -143,9 +142,9 @@ public class ClientFlowTest {
         assertJmxValue(oNameHC, "MaxConnections", 41);
         assertJmxValue(oNameHC, "Environment", "PROD");
         assertJmxValue(oNameCB, "MaxFailures", 11);
-        assertJmxValue(oNameCB, "CallTimeout", "12 seconds");
-        assertJmxValue(oNameCB, "ResetTimeout", "13 minutes");
-        assertJmxValue(oNameCB, "MaxResetTimeout", "14 days");
+        assertJmxValue(oNameCB, "CallTimeout", "12000 milliseconds"); // 12 seconds
+        assertJmxValue(oNameCB, "ResetTimeout", "780000 milliseconds"); // 13 minutes
+        assertJmxValue(oNameCB, "MaxResetTimeout", "1209600000 milliseconds"); // 14 days
         assertJmxValue(oNameCB, "ExponentialBackoffFactor", 16.0);
     }
 
@@ -157,9 +156,9 @@ public class ClientFlowTest {
                         AtomicCircuitBreakerState.create(
                                 "javaAllInputsClient",
                                 11,
-                                FiniteDuration.apply(12, TimeUnit.SECONDS),
-                                FiniteDuration.apply(13, TimeUnit.MINUTES),
-                                FiniteDuration.apply(14, TimeUnit.DAYS),
+                                Duration.ofSeconds(12),
+                                Duration.ofMinutes(13),
+                                Duration.ofDays(14),
                                 16.0,
                                 system.dispatcher(),
                                 system.scheduler()));
@@ -190,9 +189,9 @@ public class ClientFlowTest {
         assertJmxValue(oNameHC, "MaxConnections", 41);
         assertJmxValue(oNameHC, "Environment", "PROD");
         assertJmxValue(oNameCB, "MaxFailures", 11);
-        assertJmxValue(oNameCB, "CallTimeout", "12 seconds");
-        assertJmxValue(oNameCB, "ResetTimeout", "13 minutes");
-        assertJmxValue(oNameCB, "MaxResetTimeout", "14 days");
+        assertJmxValue(oNameCB, "CallTimeout", "12000 milliseconds"); // 12 seconds
+        assertJmxValue(oNameCB, "ResetTimeout", "780000 milliseconds"); // 13 minutes
+        assertJmxValue(oNameCB, "MaxResetTimeout", "1209600000 milliseconds"); // 14 days
         assertJmxValue(oNameCB, "ExponentialBackoffFactor", 16.0);
     }
 

--- a/squbs-pattern/src/main/java/org/squbs/pattern/timeoutpolicy/TimedFn.java
+++ b/squbs-pattern/src/main/java/org/squbs/pattern/timeoutpolicy/TimedFn.java
@@ -16,9 +16,9 @@
 
 package org.squbs.pattern.timeoutpolicy;
 
-import scala.concurrent.duration.FiniteDuration;
+import java.time.Duration;
 
 @FunctionalInterface
 public interface TimedFn<T> {
-    T get(FiniteDuration t) throws Exception;
+    T get(Duration t) throws Exception;
 }

--- a/squbs-pattern/src/main/scala/org/squbs/pattern/timeoutpolicy/TimeoutPolicy.scala
+++ b/squbs-pattern/src/main/scala/org/squbs/pattern/timeoutpolicy/TimeoutPolicy.scala
@@ -17,6 +17,7 @@
 package org.squbs.pattern.timeoutpolicy
 
 import java.lang.management.ManagementFactory
+import java.util.concurrent.TimeUnit
 
 import akka.agent.Agent
 import com.typesafe.scalalogging.LazyLogging
@@ -92,7 +93,7 @@ abstract class TimeoutPolicy(name: Option[String], initial: FiniteDuration, star
 
   // API for java
   def execute[T](f: TimedFn[T]): T = {
-    execute((t: FiniteDuration) => f.get(t))
+    execute((t: FiniteDuration) => f.get(java.time.Duration.ofNanos(t.toNanos)))
   }
 
   /**
@@ -276,8 +277,8 @@ object TimeoutPolicy extends LazyLogging {
  * Java API
  */
 object TimeoutPolicyBuilder {
-  def create(initial: FiniteDuration, ec: ExecutionContext) =
-    TimeoutPolicyBuilder(initial = initial)(ec)
+  def create(initial: java.time.Duration, ec: ExecutionContext) =
+    TimeoutPolicyBuilder(initial = FiniteDuration(initial.getNano, TimeUnit.NANOSECONDS))(ec)
 }
 
 case class TimeoutPolicyBuilder(name: Option[String] = None,

--- a/squbs-pattern/src/main/scala/org/squbs/pattern/timeoutpolicy/TimeoutPolicy.scala
+++ b/squbs-pattern/src/main/scala/org/squbs/pattern/timeoutpolicy/TimeoutPolicy.scala
@@ -25,6 +25,7 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.squbs.util.DurationConverters._
 
 /**
  *
@@ -93,7 +94,7 @@ abstract class TimeoutPolicy(name: Option[String], initial: FiniteDuration, star
 
   // API for java
   def execute[T](f: TimedFn[T]): T = {
-    execute((t: FiniteDuration) => f.get(java.time.Duration.ofNanos(t.toNanos)))
+    execute((t: FiniteDuration) => f.get(toJava(t)))
   }
 
   /**
@@ -278,7 +279,7 @@ object TimeoutPolicy extends LazyLogging {
  */
 object TimeoutPolicyBuilder {
   def create(initial: java.time.Duration, ec: ExecutionContext) =
-    TimeoutPolicyBuilder(initial = FiniteDuration(initial.getNano, TimeUnit.NANOSECONDS))(ec)
+    TimeoutPolicyBuilder(initial = toScala(initial))(ec)
 }
 
 case class TimeoutPolicyBuilder(name: Option[String] = None,

--- a/squbs-pattern/src/test/java/org/squbs/pattern/timeoutpolicy/TimeoutPolicyJ.java
+++ b/squbs-pattern/src/test/java/org/squbs/pattern/timeoutpolicy/TimeoutPolicyJ.java
@@ -17,6 +17,7 @@
 package org.squbs.pattern.timeoutpolicy;
 
 import akka.actor.ActorSystem;
+import org.squbs.util.DurationConverters;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
@@ -73,7 +74,7 @@ public class TimeoutPolicyJ {
         } catch (Exception e) {
             System.out.println(e);
         }
-        return Duration.ofMillis(policy.waitTime().toMillis());
+        return DurationConverters.toJava(policy.waitTime());
     }
 
     public Duration invokeExecuteClosure(TimeoutPolicy policy) {
@@ -85,20 +86,20 @@ public class TimeoutPolicyJ {
         } catch (Exception e) {
             System.out.println(e);
         }
-        return Duration.ofMillis(policy.waitTime().toMillis());
+        return DurationConverters.toJava(policy.waitTime());
     }
 
     public Duration invokeInline(TimeoutPolicy policy) {
         TimeoutPolicy.TimeoutTransaction tx = policy.transaction();
         try {
-            return timedFn.get(Duration.ofMillis(tx.waitTime().toMillis()));
+            return timedFn.get(DurationConverters.toJava(tx.waitTime()));
         } catch (Exception e) {
             System.out.println(e);
         } finally {
             tx.end();
         }
-        return Duration.ofMillis(policy.waitTime().toMillis());
-    }
+        return DurationConverters.toJava(policy.waitTime());
+   }
 
     public TimeoutPolicy getFixedTimeoutPolicy() {
         return fixedTimeoutPolicy;

--- a/squbs-pattern/src/test/java/org/squbs/pattern/timeoutpolicy/TimeoutPolicyJ.java
+++ b/squbs-pattern/src/test/java/org/squbs/pattern/timeoutpolicy/TimeoutPolicyJ.java
@@ -17,8 +17,8 @@
 package org.squbs.pattern.timeoutpolicy;
 
 import akka.actor.ActorSystem;
-import scala.concurrent.duration.FiniteDuration;
 
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,13 +34,13 @@ public class TimeoutPolicyJ {
     private final TimeoutPolicy sigmaTimeoutPolicy;
     private final TimeoutPolicy percentileTimeoutPolicy;
     // callable randomized duration between 50 ms to 150 ms
-    private Callable<FiniteDuration> timedCall = () -> {
+    private Callable<Duration> timedCall = () -> {
         // 100 ms +- 50 ms randomize offset
         int waitTime = (int) (Math.random() * 100 + 50);
         Thread.sleep(waitTime);
-        return new FiniteDuration(waitTime, MILLISECONDS);
+        return Duration.ofMillis(waitTime);
     };
-    private TimedFn<FiniteDuration> timedFn = (FiniteDuration t) -> {
+    private TimedFn<Duration> timedFn = (Duration t) -> {
         // offset 20 ms on top of what's set in the timeout policy
         // empirical policies will skew left due to timeout cut-off at the right-side tail
         // offset will allow the sigma to breathe for the future.get()
@@ -49,55 +49,55 @@ public class TimeoutPolicyJ {
 
     public TimeoutPolicyJ() {
         fixedTimeoutPolicy = TimeoutPolicyBuilder
-                .create(new FiniteDuration(INITIAL_TIMEOUT, MILLISECONDS), fromExecutorService(es))
+                .create(Duration.ofMillis(INITIAL_TIMEOUT), fromExecutorService(es))
                 .minSamples(1)
                 .rule(TimeoutPolicyType.FIXED)
                 .build();
         sigmaTimeoutPolicy = TimeoutPolicyBuilder
-                .create(new FiniteDuration(INITIAL_TIMEOUT, MILLISECONDS), system.dispatcher())
+                .create(Duration.ofMillis(INITIAL_TIMEOUT), system.dispatcher())
                 .minSamples(1)
                 .name("SIGMA")
                 .rule(3.0, TimeoutPolicyType.SIGMA)
                 .build();
         percentileTimeoutPolicy = TimeoutPolicyBuilder
-                .create(new FiniteDuration(INITIAL_TIMEOUT, MILLISECONDS), system.dispatcher())
+                .create(Duration.ofMillis(INITIAL_TIMEOUT), system.dispatcher())
                 .minSamples(1)
                 .name("PERCENTILE")
                 .rule(95, TimeoutPolicyType.PERCENTILE)
                 .build();
     }
 
-    public FiniteDuration invokeExecute(TimeoutPolicy policy) {
+    public Duration invokeExecute(TimeoutPolicy policy) {
         try {
             return policy.execute(timedFn);
         } catch (Exception e) {
             System.out.println(e);
         }
-        return policy.waitTime();
+        return Duration.ofMillis(policy.waitTime().toMillis());
     }
 
-    public FiniteDuration invokeExecuteClosure(TimeoutPolicy policy) {
+    public Duration invokeExecuteClosure(TimeoutPolicy policy) {
         try {
             // casting (TimedFn<FiniteDuration>) is not required by the compiler, but intelliJ needs it
-            return policy.execute((TimedFn<FiniteDuration>) (FiniteDuration t) -> {
+            return policy.execute((TimedFn<Duration>) (Duration t) -> {
                 return es.submit(timedCall).get(t.toMillis() + 20, MILLISECONDS);
             });
         } catch (Exception e) {
             System.out.println(e);
         }
-        return policy.waitTime();
+        return Duration.ofMillis(policy.waitTime().toMillis());
     }
 
-    public FiniteDuration invokeInline(TimeoutPolicy policy) {
+    public Duration invokeInline(TimeoutPolicy policy) {
         TimeoutPolicy.TimeoutTransaction tx = policy.transaction();
         try {
-            return timedFn.get(tx.waitTime());
+            return timedFn.get(Duration.ofMillis(tx.waitTime().toMillis()));
         } catch (Exception e) {
             System.out.println(e);
         } finally {
             tx.end();
         }
-        return policy.waitTime();
+        return Duration.ofMillis(policy.waitTime().toMillis());
     }
 
     public TimeoutPolicy getFixedTimeoutPolicy() {

--- a/squbs-pattern/src/test/scala/org/squbs/pattern/timeoutpolicy/TimeoutPolicySpec.scala
+++ b/squbs-pattern/src/test/scala/org/squbs/pattern/timeoutpolicy/TimeoutPolicySpec.scala
@@ -42,8 +42,8 @@ class TimeoutPolicySpec extends FlatSpecLike with Matchers{
   "Run FixedTimeoutPolicy in function" should "work" in {
     val policy = TimeoutPolicy(name = Some("test"), initial = 1.second, fixedRule, minSamples = 1)
 
-    for(i <- 0 until 10) {
-      policy.execute(timeout => {
+    for(_ <- 0 until 10) {
+      policy.execute((timeout: FiniteDuration) => {
         timeout should be(1.second)
         Thread.sleep(10)
       })

--- a/squbs-unicomplex/src/test/java/org/squbs/lifecycle/GracefulStopHelperTest.java
+++ b/squbs-unicomplex/src/test/java/org/squbs/lifecycle/GracefulStopHelperTest.java
@@ -8,6 +8,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -60,7 +61,7 @@ public class GracefulStopHelperTest {
         }
 
         @Override
-        public CompletionStage<Boolean> gracefulStop(ActorRef target, long timeout, TimeUnit unit, Object stopMessage) {
+        public CompletionStage<Boolean> gracefulStop(ActorRef target, Duration duration, Object stopMessage) {
             return CompletableFuture.supplyAsync(() -> { throw new RuntimeException("BadMan"); });
         }
     }
@@ -78,7 +79,7 @@ public class GracefulStopHelperTest {
         }
 
         @Override
-        public CompletionStage<Boolean> gracefulStop(ActorRef target, long timeout, TimeUnit unit, Object stopMessage) {
+        public CompletionStage<Boolean> gracefulStop(ActorRef target, Duration duration, Object stopMessage) {
             return CompletableFuture.supplyAsync(() -> true);
         }
     }

--- a/squbs-unicomplex/src/test/java/org/squbs/stream/KillSwitchStreamJ.java
+++ b/squbs-unicomplex/src/test/java/org/squbs/stream/KillSwitchStreamJ.java
@@ -10,6 +10,7 @@ import akka.stream.javadsl.*;
 import org.squbs.unicomplex.Timeouts;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,7 @@ public class KillSwitchStreamJ extends AbstractPerpetualStream<CompletionStage<L
             );
 
             FlowShape<Integer, Integer> throttle = builder.add(Flow.<Integer>create().throttle(5000,
-                    FiniteDuration.create(1, TimeUnit.SECONDS), 1000,
+                    Duration.ofSeconds(1), 1000,
                     ThrottleMode.shaping()));
 
             FlowShape<Integer, Integer> killSwitch = builder.add(killSwitch().<Integer>flow());

--- a/squbs-unicomplex/src/test/java/org/squbs/stream/KillSwitchWithChildActorStreamJ.java
+++ b/squbs-unicomplex/src/test/java/org/squbs/stream/KillSwitchWithChildActorStreamJ.java
@@ -11,15 +11,14 @@ import akka.stream.SourceShape;
 import akka.stream.ThrottleMode;
 import akka.stream.javadsl.*;
 import org.squbs.unicomplex.Timeouts;
-import scala.concurrent.duration.FiniteDuration;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class KillSwitchWithChildActorStreamJ  extends AbstractPerpetualStream<CompletionStage<Long>> {
+public class KillSwitchWithChildActorStreamJ extends AbstractPerpetualStream<CompletionStage<Long>> {
 
     static final AtomicLong genCount = new AtomicLong(0L);
 
@@ -52,7 +51,7 @@ public class KillSwitchWithChildActorStreamJ  extends AbstractPerpetualStream<Co
             );
 
             FlowShape<Integer, Integer> throttle = builder.add(Flow.<Integer>create().throttle(5000,
-                    FiniteDuration.create(1, TimeUnit.SECONDS), 1000,
+                    Duration.ofSeconds(1), 1000,
                     ThrottleMode.shaping()));
 
             FlowShape<Integer, Integer> killSwitch = builder.add(killSwitch().<Integer>flow());

--- a/squbs-unicomplex/src/test/java/org/squbs/stream/ProperShutdownStreamJ.java
+++ b/squbs-unicomplex/src/test/java/org/squbs/stream/ProperShutdownStreamJ.java
@@ -9,6 +9,7 @@ import akka.stream.FlowShape;
 import akka.stream.ThrottleMode;
 import akka.stream.javadsl.*;
 import org.squbs.unicomplex.Timeouts;
+import org.squbs.util.DurationConverters;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -73,7 +74,7 @@ public class ProperShutdownStreamJ extends AbstractPerpetualStream<Pair<ActorRef
         ActorRef actorRef = matValue().first();
         CompletionStage<Long> fCount = matValue().second();
         CompletionStage<Boolean> fStopped =
-                gracefulStop(actorRef, Duration.ofSeconds(Timeouts.awaitMax().toSeconds()));
+                gracefulStop(actorRef, DurationConverters.toJava(Timeouts.awaitMax()));
         return fCount.thenCombine(fStopped, (count, stopped) -> Done.getInstance());
     }
 }


### PR DESCRIPTION
Merging all work from #706 as well as standardized the time conversion, especially from Java to Scala to retain the coarsest possible unit. For instance, a time of `Duration.ofSeconds(120)` will end up as `2 minutes` in the `FiniteDuration`.

Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [ ] Commits are squashed.
- [ ] Tests added.
- [x] Documentation added/updated.
- [x] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
