### PR TITLE
Replace deprecated method - akka.pattern.PatternsCS.ask (#703)

### DIFF
--- a/squbs-ext/src/test/java/org/squbs/streams/TimeoutTest.java
+++ b/squbs-ext/src/test/java/org/squbs/streams/TimeoutTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.time.Duration;
 
-import static akka.pattern.PatternsCS.ask;
+import static akka.pattern.Patterns.ask;
 import static scala.compat.java8.JFunction.*;
 
 public class TimeoutTest {
@@ -57,7 +57,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<String, String, NotUsed> flow =
                 Flow.<String>create()
-                        .mapAsync(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsync(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (String)elem);
 
 
@@ -80,7 +80,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<String, String, NotUsed> flow =
                 Flow.<String>create()
-                        .mapAsync(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsync(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (String)elem);
 
         Consumer<String> cleanUp = s -> counter.incrementAndGet();
@@ -103,7 +103,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, UUID>, Pair<String, UUID>, NotUsed> flow =
                 Flow.<Pair<String, UUID>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, UUID>)elem);
 
         final BidiFlow<Pair<String, UUID>, Pair<String, UUID>, Pair<String, UUID>, Pair<Try<String>, UUID>, NotUsed> timeoutBidiFlow =
@@ -140,7 +140,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, MyContext>, Pair<String, MyContext>, NotUsed> flow =
                 Flow.<Pair<String, MyContext>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, MyContext>)elem);
 
         TimeoutSettings settings = TimeoutSettings.<String, String, MyContext>create(timeout)
@@ -186,7 +186,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, MyContext>, Pair<String, MyContext>, NotUsed> flow =
                 Flow.<Pair<String, MyContext>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, MyContext>)elem);
 
 
@@ -224,7 +224,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, UniqueId.Envelope>, Pair<String, UniqueId.Envelope>, NotUsed> flow =
                 Flow.<Pair<String, UniqueId.Envelope>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, UniqueId.Envelope>)elem);
 
 
@@ -251,7 +251,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, UUID>, Pair<String, UUID>, NotUsed> flow =
                 Flow.<Pair<String, UUID>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, UUID>)elem);
 
         Consumer<String> cleanUp = s -> counter.incrementAndGet();
@@ -290,7 +290,7 @@ public class TimeoutTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, MyContext>, Pair<String, MyContext>, NotUsed> flow =
                 Flow.<Pair<String, MyContext>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, MyContext>)elem);
 
         Consumer<String> cleanUp = s -> counter.incrementAndGet();

--- a/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerTest.java
+++ b/squbs-ext/src/test/java/org/squbs/streams/circuitbreaker/CircuitBreakerTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import static akka.pattern.PatternsCS.ask;
+import static akka.pattern.Patterns.ask;
 
 public class CircuitBreakerTest {
 
@@ -69,7 +69,7 @@ public class CircuitBreakerTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, UUID>, Pair<String, UUID>, NotUsed> flow =
                 Flow.<Pair<String, UUID>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, UUID>)elem);
 
 
@@ -105,7 +105,7 @@ public class CircuitBreakerTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, UUID>, Pair<String, UUID>, NotUsed> flow =
                 Flow.<Pair<String, UUID>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, UUID>)elem);
 
         final CircuitBreakerState circuitBreakerState =
@@ -156,7 +156,7 @@ public class CircuitBreakerTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, Integer>, Pair<String, Integer>, NotUsed> flow =
                 Flow.<Pair<String, Integer>>create()
-                        .mapAsyncUnordered(2, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(2, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, Integer>)elem);
 
         final CircuitBreakerState circuitBreakerState =
@@ -237,7 +237,7 @@ public class CircuitBreakerTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, MyContext>, Pair<String, MyContext>, NotUsed> flow =
                 Flow.<Pair<String, MyContext>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, MyContext>)elem);
 
         final CircuitBreakerState circuitBreakerState =
@@ -314,7 +314,7 @@ public class CircuitBreakerTest {
         final ActorRef delayActor = system.actorOf(Props.create(DelayActor.class));
         final Flow<Pair<String, MyContext>, Pair<String, MyContext>, NotUsed> flow =
                 Flow.<Pair<String, MyContext>>create()
-                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, 5000))
+                        .mapAsyncUnordered(3, elem -> ask(delayActor, elem, Duration.ofSeconds(5)))
                         .map(elem -> (Pair<String, MyContext>)elem);
 
         final CircuitBreakerState circuitBreakerState =

--- a/squbs-testkit/src/test/java/org/squbs/testkit/japi/InfoRouteWithActor.java
+++ b/squbs-testkit/src/test/java/org/squbs/testkit/japi/InfoRouteWithActor.java
@@ -22,8 +22,11 @@ import akka.http.javadsl.model.headers.RawHeader;
 import akka.http.javadsl.server.Route;
 import org.squbs.unicomplex.AbstractRouteDefinition;
 
-import static akka.pattern.PatternsCS.*;
-import static akka.http.javadsl.server.PathMatchers.*;
+import java.time.Duration;
+
+import static akka.http.javadsl.server.PathMatchers.integerSegment;
+import static akka.http.javadsl.server.PathMatchers.segment;
+import static akka.pattern.Patterns.ask;
 
 public class InfoRouteWithActor extends AbstractRouteDefinition {
 
@@ -33,7 +36,7 @@ public class InfoRouteWithActor extends AbstractRouteDefinition {
                 path(segment().slash(integerSegment()), (ops, input) ->
                         onSuccess(() ->
                                 ask(context().actorSelection("/user/CustomTestKitDefaultSpec/" + ops + "Actor"),
-                                        input, 30000L), response -> complete(HttpResponse.create()
+                                        input, Duration.ofSeconds(30)), response -> complete(HttpResponse.create()
                                         .addHeader(RawHeader.create("foo", "bar"))
                                         .withEntity(
                                                 HttpEntities.create(ContentTypes.APPLICATION_JSON,


### PR DESCRIPTION
Fix #703.

Replace deprecated method - `akka.pattern.PatternsCS.ask` with `akka.pattern.Patterns.ask`

Thanks for your pull request.  Please review the following guidelines.

- [x] Title includes issue id.
- [x] Description of the change added.
- [x] Commits are squashed.
- [ ] Tests added.
- [ ] Documentation added/updated.
- [ ] Also please review [CONTRIBUTING.md](https://github.com/paypal/squbs/blob/master/CONTRIBUTING.md).
