### PR TITLE
PersistentBufferAtLeastOnce: Don't drop elements if no commits are made

### DIFF
--- a/squbs-pattern/src/main/scala/org/squbs/pattern/stream/PersistentQueue.scala
+++ b/squbs-pattern/src/main/scala/org/squbs/pattern/stream/PersistentQueue.scala
@@ -98,8 +98,9 @@ class PersistentQueue[T](config: QueueConfig, onCommitCallback: Int => Unit = _ 
     0 until outputPorts foreach { outputPortId =>
       val startIdx = read(outputPortId)
       logger.info("Setting idx for outputPort {} - {}", outputPortId.toString, startIdx.toString)
-      reader(outputPortId).moveToIndex(startIdx)
-      dequeue(outputPortId) // dequeue the first read element
+      if (reader(outputPortId).moveToIndex(startIdx)) {
+        dequeue(outputPortId) // dequeue the first read element if resumed from index
+      }
       lastCommitIndex(outputPortId) = startIdx
       cycle(outputPortId) = queue.rollCycle().toCycle(startIdx)
     }


### PR DESCRIPTION
When the queue is started, it attempts to resume from the old
index. However, this operation may fail if e.g. no commits have
occurred yet.

This ensures that the first element is only dropped if resuming
from an index succeeds, and adds a test to validate this behavior.
